### PR TITLE
[feat/] 회원가입 로직 구현

### DIFF
--- a/src/main/java/com/practice/course_registration/config/SecurityConfig.java
+++ b/src/main/java/com/practice/course_registration/config/SecurityConfig.java
@@ -4,11 +4,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -22,7 +27,7 @@ public class SecurityConfig {
                 );
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/h2-console/**").permitAll() // 일단 개발을 위해서 모든 접근 허용. 필요 시 수정
+                        .requestMatchers("/", "/h2-console/**", "/join").permitAll() // 일단 개발을 위해서 모든 접근 허용. 필요 시 수정
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/practice/course_registration/controller/JoinController.java
+++ b/src/main/java/com/practice/course_registration/controller/JoinController.java
@@ -1,0 +1,32 @@
+package com.practice.course_registration.controller;
+
+import com.practice.course_registration.dto.JoinDTO;
+import com.practice.course_registration.service.JoinService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Slf4j
+@Controller
+public class JoinController {
+    private final JoinService joinService;
+    public JoinController(JoinService joinService) {
+        this.joinService = joinService;
+    }
+
+    @GetMapping("/join")
+    public String joinPage(){
+        return "join";
+    }
+
+    @PostMapping("/join")
+    public String joinProcess(JoinDTO joinDTO){
+        log.info("[joinProcess] joinDTO: {}", joinDTO);
+
+        joinService.joinProcess(joinDTO);
+
+        return "redirect:/login";
+    }
+
+}

--- a/src/main/java/com/practice/course_registration/dto/JoinDTO.java
+++ b/src/main/java/com/practice/course_registration/dto/JoinDTO.java
@@ -1,0 +1,19 @@
+package com.practice.course_registration.dto;
+
+import jakarta.persistence.Column;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class JoinDTO {
+    private String memberName;
+    private String memberNumber;
+
+    private int grade; // 학년
+
+    private String memberEmail;
+
+    private String memberId; // 로그인용 ID
+    private String password; // 로그인용 PW
+}

--- a/src/main/java/com/practice/course_registration/entity/MemberEntity.java
+++ b/src/main/java/com/practice/course_registration/entity/MemberEntity.java
@@ -1,0 +1,56 @@
+package com.practice.course_registration.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(unique = true, nullable = false)
+    private String memberName;
+
+    @Column(unique = true, nullable = false)
+    private String memberNumber; // 학번
+
+    private int grade; // 학년
+
+    @Column(unique = true, nullable = true)
+    private String memberEmail; // 인증용 메일(추후 기능 추가)
+
+    @Column(unique = true, nullable = false)
+    private String memberId; // 로그인용 ID
+
+    @Column(nullable = false)
+    private String password; // 로그인용 PW
+
+    private String role;
+
+    public MemberEntity(String memberName, String memberNumber, int grade, String memberId, String password) {
+        this.memberName = memberName;
+        this.memberNumber = memberNumber;
+        this.grade = grade;
+        this.memberId = memberId;
+        this.password = password;
+        this.role = "ROLE_USER"; // 기본값
+    }
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
+    public void changeGrade(int grade) {
+        this.grade = grade;
+    }
+
+    public void changeEmail(String memberEmail) {
+        this.memberEmail = memberEmail;
+    }
+}

--- a/src/main/java/com/practice/course_registration/repository/MemberRepository.java
+++ b/src/main/java/com/practice/course_registration/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.practice.course_registration.repository;
+
+import com.practice.course_registration.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+    boolean existsByMemberId(String memberId);
+    boolean existsByMemberNumber(String memberNumber);
+}

--- a/src/main/java/com/practice/course_registration/service/JoinService.java
+++ b/src/main/java/com/practice/course_registration/service/JoinService.java
@@ -1,0 +1,56 @@
+package com.practice.course_registration.service;
+
+import com.practice.course_registration.dto.JoinDTO;
+import com.practice.course_registration.entity.MemberEntity;
+import com.practice.course_registration.repository.MemberRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JoinService {
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    public JoinService(MemberRepository memberRepository, BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.memberRepository = memberRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    public void joinProcess(JoinDTO joinDTO) {
+        // 자릿수, 특수문자 등은 추후에 추가.
+        checkDuplicateMember(joinDTO);
+
+        MemberEntity member = createMember(joinDTO);
+        memberRepository.save(member);
+    }
+
+    private void checkDuplicateMember(JoinDTO joinDTO) {
+        // DB에 이미 동일한 로그인용 ID(memberID)를 가진 회원이 존재하는지
+        boolean duplicateMemberId = memberRepository.existsByMemberId(joinDTO.getMemberId());
+        if (duplicateMemberId) {
+            throw new IllegalArgumentException("동일한 로그인 ID를 가진 회원이 존재합니다.");
+        }
+
+        // DB에 이미 동일한 memberNumber(학번)을 가진 회원이 존재하는지
+        boolean duplicateMemberNumber = memberRepository.existsByMemberNumber(joinDTO.getMemberNumber());
+        if (duplicateMemberNumber) {
+            throw new IllegalArgumentException("동일한 학번을 가진 회원이 존재합니다.");
+        }
+    }
+
+    private MemberEntity createMember(JoinDTO joinDTO) {
+        MemberEntity member = new MemberEntity(
+                joinDTO.getMemberName(),
+                joinDTO.getMemberNumber(),
+                joinDTO.getGrade(),
+                joinDTO.getMemberId(),
+                bCryptPasswordEncoder.encode(joinDTO.getPassword())
+        );
+
+        if (joinDTO.getMemberEmail() != null)
+            member.changeEmail(joinDTO.getMemberEmail());
+
+        return member;
+    }
+
+
+}

--- a/src/main/resources/templates/join.html
+++ b/src/main/resources/templates/join.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>회원가입</title>
+</head>
+<body>
+<h2>회원가입 정보 입력</h2>
+<form th:action="@{/join}" method="post">
+    <label for="memberName">이름:</label>
+    <input type="text" id="memberName" name="memberName" required/><br/><br/>
+
+    <label for="memberNumber">학번:</label>
+    <input type="text" id="memberNumber" name="memberNumber" required/><br/><br/>
+
+    <label for="grade">학년:</label>
+    <input type="number" id="grade" name="grade" min="1" max="4" required/><br/><br/>
+
+    <label for="memberEmail">이메일:</label>
+    <input type="email" id="memberEmail" name="memberEmail" placeholder="선택사항"/><br/><br/>
+
+    <label for="memberId">로그인 ID:</label>
+    <input type="text" id="memberId" name="memberId" required/><br/><br/>
+
+    <label for="password">비밀번호:</label>
+    <input type="password" id="password" name="password" required/><br/><br/>
+
+    <button type="submit">회원가입</button>
+</form>
+</body>
+</html>

--- a/src/test/java/com/practice/course_registration/JoinServiceTest.java
+++ b/src/test/java/com/practice/course_registration/JoinServiceTest.java
@@ -1,0 +1,112 @@
+package com.practice.course_registration;
+
+import com.practice.course_registration.dto.JoinDTO;
+import com.practice.course_registration.entity.MemberEntity;
+import com.practice.course_registration.repository.MemberRepository;
+import com.practice.course_registration.service.JoinService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith({MockitoExtension.class})
+class JoinServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @InjectMocks
+    private JoinService joinService;
+
+    private JoinDTO joinDTO;
+
+    @BeforeEach
+    void setUp() {
+        joinDTO = new JoinDTO();
+        joinDTO.setMemberName("하냥이");
+        joinDTO.setMemberId("hanyang");
+        joinDTO.setPassword("20250816");
+        joinDTO.setGrade(4);
+        joinDTO.setMemberEmail("hanyang@hanyang.ac.kr");
+        joinDTO.setMemberNumber("2025001002");
+    }
+
+    @Test
+    @DisplayName("회원 가입 성공")
+    void joinProcess_Success() {
+        //given
+        when(memberRepository.existsByMemberId(joinDTO.getMemberId())).thenReturn(false);
+        when(memberRepository.existsByMemberNumber(joinDTO.getMemberNumber())).thenReturn(false);
+        when(bCryptPasswordEncoder.encode(joinDTO.getPassword())).thenReturn("encodedPassword");
+
+        //when
+        joinService.joinProcess(joinDTO);
+
+        //then
+        verify(memberRepository, times(1)).existsByMemberId(joinDTO.getMemberId());
+        verify(memberRepository, times(1)).existsByMemberNumber(joinDTO.getMemberNumber());
+        verify(bCryptPasswordEncoder, times(1)).encode(joinDTO.getPassword());
+        verify(memberRepository, times(1)).save(any(MemberEntity.class));
+    }
+
+    @Test
+    @DisplayName("학번 중복으로 회원가입 실패")
+    void joinProcess_DuplicateMemberNumber_Fail() {
+        //given
+        when(memberRepository.existsByMemberId(joinDTO.getMemberId())).thenReturn(false);
+        when(memberRepository.existsByMemberNumber(joinDTO.getMemberNumber())).thenReturn(true);
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> joinService.joinProcess(joinDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("동일한 학번을 가진 회원이 존재합니다."); // 문자열로 비교하는 것을 나중에 에러 핸들링하면서 바꾸는 게 좋을듯
+
+        // 학번 중복이므로 save 호출 X
+        verify(memberRepository, never()).save(any(MemberEntity.class));
+    }
+
+    @Test
+    @DisplayName("ID 중복으로 회원가입 실패")
+    void joinProcess_DuplicateMemberId_Fail() {
+        // given
+        when(memberRepository.existsByMemberId(joinDTO.getMemberId())).thenReturn(true);
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> joinService.joinProcess(joinDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("동일한 로그인 ID를 가진 회원이 존재합니다.");
+
+        verify(memberRepository, never()).save(any(MemberEntity.class));
+    }
+
+    @Test
+    @DisplayName("이메일 없는 회원가입 성공")
+    void joinProcess_WithoutEmail_Success(){
+        //given
+        joinDTO.setMemberEmail(null);
+        when(memberRepository.existsByMemberId(joinDTO.getMemberId())).thenReturn(false);
+        when(memberRepository.existsByMemberNumber(joinDTO.getMemberNumber())).thenReturn(false);
+        when(bCryptPasswordEncoder.encode(joinDTO.getPassword())).thenReturn("encodedPassword");
+
+
+        // when
+        joinService.joinProcess(joinDTO);
+
+        //then
+        verify(memberRepository, times(1)).existsByMemberId(joinDTO.getMemberId());
+        verify(memberRepository, times(1)).existsByMemberNumber(joinDTO.getMemberNumber());
+        verify(bCryptPasswordEncoder, times(1)).encode(joinDTO.getPassword());
+        verify(memberRepository, times(1)).save(any(MemberEntity.class));
+    }
+
+
+}


### PR DESCRIPTION
## ❤️ 기능 설명

- 회원 가입 기능을 구현하였습니다. (`join.html` 사용)
- MemberEntity를 만들어서, 학번, 이름, Id, 비밀번호, 학년, 이메일을 받아서 객체를 생성하도록 하였습니다.
- 학번이 동일할 때, Id가 동일할 때 회원가입이 되지 않도록 로직을 설계하였습니다. 
- 회원 가입 로직 테스트는 `JoinServiceTest`를 이용해보시면 됩니다!

테스트 성공 결과 스크린샷 첨부
<table>
  <tr>
    <td>
      <img width="342" height="472" alt="image" src="https://github.com/user-attachments/assets/276dc729-18fe-4fd9-bb19-4ea0d9362f01" />
    </td>
    <td>
      <img width="1122" height="107" alt="image" src="https://github.com/user-attachments/assets/cd936768-2619-44c8-bc3a-6f7a149cad19" />
    </td>
  </tr>
</table>

## 연결된 issue
X

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 책임 설계가 제대로 되어있는지 확인해주세용
- [ ] 회원 가입을 이렇게 하는 게 맞는지 한번만 확인해주세용.(처음이라 두려워용..)
- [ ] 유닛 테스트 Mockito 사용하는 게 맞는지 한번만 확인해주세

<br>

## ✅ 체크리스트

- [O] PR 제목 규칙 잘 지켰는가?
- [O] 추가/수정사항을 설명하였는가?
- [O] 테스트 결과 사진을 넣었는가?
- [] 이슈넘버를 적었는가?
