### PR TITLE
[feat/#5] 공동 예외처리 핸들링 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// validate
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/practice/course_registration/apiPayload/ApiCommonResponse.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/ApiCommonResponse.java
@@ -1,0 +1,34 @@
+package com.practice.course_registration.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiCommonResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    private final String code;
+
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공시 응답
+//    public static <T> ApiCommonResponse<T> onSuccess(T result) {
+//        return new ApiCommonResponse<>(true, )
+//    }
+
+    public static <T> ApiCommonResponse<T> onFailure(String code, String message, T data) {
+        return new ApiCommonResponse<>(false, code, message, data);
+    }
+
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/ApiCommonResponse.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/ApiCommonResponse.java
@@ -3,6 +3,7 @@ package com.practice.course_registration.apiPayload;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.practice.course_registration.apiPayload.code.status.SuccessStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -23,9 +24,9 @@ public class ApiCommonResponse<T> {
 
 
     // 성공시 응답
-//    public static <T> ApiCommonResponse<T> onSuccess(T result) {
-//        return new ApiCommonResponse<>(true, )
-//    }
+    public static <T> ApiCommonResponse<T> onSuccess(T result) {
+        return new ApiCommonResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
 
     public static <T> ApiCommonResponse<T> onFailure(String code, String message, T data) {
         return new ApiCommonResponse<>(false, code, message, data);

--- a/src/main/java/com/practice/course_registration/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/code/BaseCode.java
@@ -1,0 +1,10 @@
+package com.practice.course_registration.apiPayload.code;
+
+
+
+public interface BaseCode {
+
+    ResponseDTO getReason();
+
+    ResponseDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package com.practice.course_registration.apiPayload.code;
+
+
+public interface BaseErrorCode {
+
+    ResponseDTO getReason();
+
+    ResponseDTO getReasonHttpStatus();
+
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/code/ResponseDTO.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/code/ResponseDTO.java
@@ -1,0 +1,20 @@
+package com.practice.course_registration.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ResponseDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() {
+        return isSuccess;
+    }
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,54 @@
+package com.practice.course_registration.apiPayload.code.status;
+
+import com.practice.course_registration.apiPayload.code.BaseErrorCode;
+import com.practice.course_registration.apiPayload.code.ResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+
+    /*
+    * @ 일반적인 응답
+    * */
+    // 400번대
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 500번대
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+
+
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+    @Override
+    public ResponseDTO getReason() {
+        return ResponseDTO.builder()
+                .isSuccess(false)
+                .message(message)
+                .code(code)
+                .build()
+                ;
+    }
+
+    @Override
+    public ResponseDTO getReasonHttpStatus() {
+        return ResponseDTO.builder()
+                .isSuccess(false)
+                .message(message)
+                .code(code)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,46 @@
+package com.practice.course_registration.apiPayload.code.status;
+
+import com.practice.course_registration.apiPayload.code.BaseCode;
+import com.practice.course_registration.apiPayload.code.ResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.awt.desktop.UserSessionEvent;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 성공 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ResponseDTO getReason() {
+        return ResponseDTO.builder()
+                .isSuccess(true)
+                .message(message)
+                .code(code)
+                .build()
+        ;
+    }
+
+    @Override
+    public ResponseDTO getReasonHttpStatus() {
+        return ResponseDTO.builder()
+                .isSuccess(true)
+                .message(message)
+                .code(code)
+                .httpStatus(httpStatus)
+                .build()
+        ;
+    }
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,116 @@
+package com.practice.course_registration.apiPayload.exception;
+
+import com.practice.course_registration.apiPayload.code.ResponseDTO;
+import com.practice.course_registration.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.validation.BindException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+
+@Slf4j
+@ControllerAdvice(annotations = {Controller.class})
+public class ExceptionAdvice {
+
+    /** 1) 도메인/비즈니스 예외: throw new ErrorHandler(ErrorStatus._FORBIDDEN) */
+    @ExceptionHandler(GeneralException.class)
+    public ModelAndView handleGeneral(GeneralException e, HttpServletRequest req) {
+        ResponseDTO dto = e.getErrorReasonHttpStatus(); // httpStatus 포함된 DTO
+        HttpStatus status = dto.getHttpStatus() != null ? dto.getHttpStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        ModelMap model = new ModelMap();
+        model.addAttribute("httpStatus", status.value());     // 숫자 상태코드(뷰에서 쓰기 편함)
+        model.addAttribute("code", dto.getCode());
+        model.addAttribute("message", dto.getMessage());
+        model.addAttribute("isSuccess", dto.getIsSuccess());
+        model.addAttribute("path", req.getRequestURI());
+
+        ModelAndView mv = new ModelAndView("error/common");
+        mv.setStatus(status); // 실제 HTTP 상태코드 설정
+        mv.addAllObjects(model);
+        return mv;
+    }
+
+    /** 2) 폼 바인딩 오류 (폼 화면으로 돌려보내지 않고 공통 에러 페이지로 보낼 때) */
+    @ExceptionHandler({ MethodArgumentNotValidException.class, BindException.class })
+    public ModelAndView handleValidation(Exception e, HttpServletRequest req) {
+        var ec = ErrorStatus._BAD_REQUEST;
+
+        String msg;
+        if (e instanceof MethodArgumentNotValidException manv) {
+            msg = manv.getBindingResult().getFieldErrors().stream()
+                    .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                    .reduce((a, b) -> a + ", " + b).orElse("Validation failed");
+        } else if (e instanceof BindException be) {
+            msg = be.getBindingResult().getFieldErrors().stream()
+                    .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                    .reduce((a, b) -> a + ", " + b).orElse("Binding failed");
+        } else {
+            msg = "Validation error";
+        }
+
+        ModelAndView mv = new ModelAndView("error/common");
+        mv.setStatus(ec.getHttpStatus());
+        mv.addObject("httpStatus", ec.getHttpStatus().value());
+        mv.addObject("code", ec.getCode());
+        mv.addObject("message", msg);
+        mv.addObject("isSuccess", false);
+        mv.addObject("path", req.getRequestURI());
+        return mv;
+    }
+
+    /** 3) 파라미터 타입 불일치 (?page=abc 등) */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ModelAndView handleTypeMismatch(MethodArgumentTypeMismatchException e, HttpServletRequest req) {
+        var ec = ErrorStatus._BAD_REQUEST;
+
+        ModelAndView mv = new ModelAndView("error/common");
+        mv.setStatus(ec.getHttpStatus());
+        mv.addObject("httpStatus", ec.getHttpStatus().value());
+        mv.addObject("code", ec.getCode());
+        mv.addObject("message", "Invalid parameter: " + e.getName());
+        mv.addObject("isSuccess", false);
+        mv.addObject("path", req.getRequestURI());
+        return mv;
+    }
+
+    /** 4) 404 (핸들러 없음) */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ModelAndView handle404(NoHandlerFoundException e, HttpServletRequest req) {
+        HttpStatus status = HttpStatus.NOT_FOUND;
+
+        ModelAndView mv = new ModelAndView("error/common");
+        mv.setStatus(status);
+        mv.addObject("httpStatus", status.value());
+        mv.addObject("code", "COMMON404");
+        mv.addObject("message", "요청한 페이지를 찾을 수 없습니다.");
+        mv.addObject("isSuccess", false);
+        mv.addObject("path", req.getRequestURI());
+        return mv;
+    }
+
+    /** 5) 예상치 못한 모든 예외 */
+    @ExceptionHandler(Exception.class)
+    public ModelAndView handleUnexpected(Exception e, HttpServletRequest req) {
+        log.error("Unexpected error", e);
+        var ec = ErrorStatus._INTERNAL_SERVER_ERROR;
+
+        ModelAndView mv = new ModelAndView("error/common");
+        mv.setStatus(ec.getHttpStatus());
+        mv.addObject("httpStatus", ec.getHttpStatus().value());
+        mv.addObject("code", ec.getCode());
+        mv.addObject("message", ec.getMessage());
+        mv.addObject("isSuccess", false);
+        mv.addObject("path", req.getRequestURI());
+        return mv;
+    }
+}
+

--- a/src/main/java/com/practice/course_registration/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.practice.course_registration.apiPayload.exception;
+
+import com.practice.course_registration.apiPayload.code.BaseErrorCode;
+import com.practice.course_registration.apiPayload.code.ResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ResponseDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ResponseDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/practice/course_registration/apiPayload/exception/handler/ErrorHandler.java
+++ b/src/main/java/com/practice/course_registration/apiPayload/exception/handler/ErrorHandler.java
@@ -1,0 +1,10 @@
+package com.practice.course_registration.apiPayload.exception.handler;
+
+import com.practice.course_registration.apiPayload.code.BaseErrorCode;
+import com.practice.course_registration.apiPayload.exception.GeneralException;
+
+public class ErrorHandler extends GeneralException {
+    public ErrorHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/resources/templates/error/common.html
+++ b/src/main/resources/templates/error/common.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+    <head><meta charset="UTF-8">
+        <title>Error</title>
+    </head>
+    <body>
+        <h1 th:text="${httpStatus}">500</h1>
+        <p>code: <span th:text="${code}">COMMON500</span></p>
+        <p>message: <span th:text="${message}">서버 에러, 관리자에게 문의 바랍니다.</span></p>
+        <p>isSuccess: <span th:text="${isSuccess}">false</span></p>
+        <p>path: <span th:text="${path}">/path</span></p>
+        <a href="/">홈으로</a>
+    </body>
+</html>


### PR DESCRIPTION
## ❤️ 기능 설명
공동으로 사용할 예외코드를 구현
RESTAPI에 반환하는 용도로만 구현하다가 SSR 방식 고려해서 하니까 쉽지 않네요 ..

테스트 성공 결과 스크린샷 첨부
테스트를 위해 예외 던지기
<img width="995" height="339" alt="스크린샷 2025-08-20 003229" src="https://github.com/user-attachments/assets/8159ae8a-eee8-4fa6-9530-94d8bacb4818" />

html에 에러 코드 뜨는 거 확인
<img width="1006" height="512" alt="스크린샷 2025-08-20 003106" src="https://github.com/user-attachments/assets/36b19f32-f1cd-42bf-beb0-31aba72138da" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #5 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 예외 던진 것들 이렇게 바꿔주세오
- [x] yml파일에 추가된 사항 있어서 노션에 넣어둘게용

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
