### PR TITLE
[feat/#12] 수강신청 메인페이지 구현

### DIFF
--- a/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
@@ -1,0 +1,59 @@
+package com.practice.course_registration.domain.subject.controller;
+
+import com.practice.course_registration.domain.subject.dto.CourseFilterRequestDTO;
+import com.practice.course_registration.domain.subject.dto.SubjectResponseDTO;
+import com.practice.course_registration.domain.subject.service.SubjectQueryService;
+import com.practice.course_registration.domain.subject.service.SubjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/courses")
+@Validated
+public class SubjectContoller {
+
+    private final SubjectService subjectService;
+    private final SubjectQueryService subjectQueryService;
+
+    /*
+    * 기본 수강신청 페이지
+    * */
+    @GetMapping
+    public String page(Model model){
+        model.addAttribute("subjects", List.of());
+        model.addAttribute("filters", new CourseFilterRequestDTO());
+        model.addAttribute("hasSearched", false);
+        return "courses/register-form";
+    }
+
+    /*
+    * 필터링 목록 포함해서 과목 조회 페이지
+    * */
+    @GetMapping("/search")
+    public String search(CourseFilterRequestDTO filters,
+                         Model model,
+                         @PageableDefault(size = 3, sort = "subjectName", direction = Sort.Direction.ASC) Pageable pageable) {
+
+        Long memberId = 1L;
+
+        Page<SubjectResponseDTO> subjects = subjectQueryService.searchAllSubject(memberId, filters, pageable);
+
+        model.addAttribute("subjects", subjects.getContent());
+        model.addAttribute("filters", filters);
+        model.addAttribute("page", subjects);
+        model.addAttribute("hasSearched", true);
+
+        return "courses/register-form";
+    }
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
@@ -28,6 +28,7 @@ public class Subject extends BaseEntity {
 
     private String code;
 
+    @Enumerated(EnumType.STRING)
     private SubjectDay subjectDay; // 수업 요일 (교양이라 하루만 한다는 전제)
 
     private LocalTime startTime;

--- a/src/main/java/com/practice/course_registration/domain/subject/dto/CourseFilterRequestDTO.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/dto/CourseFilterRequestDTO.java
@@ -1,14 +1,9 @@
 package com.practice.course_registration.domain.subject.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Builder
-@Getter
+@Data
 @NoArgsConstructor
-@AllArgsConstructor
 public class CourseFilterRequestDTO {
     private String code; // 학수번호
     private String subjectName; // 교과명

--- a/src/main/java/com/practice/course_registration/domain/subject/dto/CourseFilterRequestDTO.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/dto/CourseFilterRequestDTO.java
@@ -1,0 +1,16 @@
+package com.practice.course_registration.domain.subject.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseFilterRequestDTO {
+    private String code; // 학수번호
+    private String subjectName; // 교과명
+    private String professorName; // 교수명
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/dto/SubjectResponseDTO.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/dto/SubjectResponseDTO.java
@@ -1,0 +1,32 @@
+package com.practice.course_registration.domain.subject.dto;
+
+import com.practice.course_registration.global.enums.SubjectDay;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class SubjectResponseDTO {
+
+    private String subjectName;
+
+    private String professorName;
+
+    private Integer limitedNum; // 제한인원
+
+    private String code;
+
+    private SubjectDay subjectDay; // 수업 요일 (교양이라 하루만 한다는 전제)
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    private Boolean registered;
+
+    private Boolean liked;
+
+
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/LikeSubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/LikeSubjectRepository.java
@@ -1,0 +1,26 @@
+package com.practice.course_registration.domain.subject.repository;
+
+import com.practice.course_registration.domain.member.domain.MemberEntity;
+import com.practice.course_registration.domain.subject.domain.LikeSubject;
+import com.practice.course_registration.domain.subject.domain.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface LikeSubjectRepository extends JpaRepository<LikeSubject, Long> {
+
+
+
+
+
+    @Query("""
+      SELECT ls.subject.id
+      FROM LikeSubject ls
+      WHERE ls.member = :member AND ls.subject.id IN :subjectIds
+    """)
+    Set<Long> findAllByMemberAndSubject(@Param("member") MemberEntity member, @Param("subjectIds") List<Long> subjectIds);
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/MemberSubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/MemberSubjectRepository.java
@@ -1,0 +1,22 @@
+package com.practice.course_registration.domain.subject.repository;
+
+import com.practice.course_registration.domain.member.domain.MemberEntity;
+import com.practice.course_registration.domain.subject.domain.MemberSubject;
+import com.practice.course_registration.domain.subject.domain.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface MemberSubjectRepository extends JpaRepository<MemberSubject, Long> {
+
+    @Query("""
+      SELECT ms.subject.id
+      FROM MemberSubject ms
+      WHERE ms.member = :member AND ms.subject.id IN :subjectIds
+    """)
+    Set<Long> findAllByMemberAndSubject(@Param("member") MemberEntity member, @Param("subjectIds") List<Long> subjectIds);
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/SubjectRepository.java
@@ -1,0 +1,26 @@
+package com.practice.course_registration.domain.subject.repository;
+
+import com.practice.course_registration.domain.subject.domain.Subject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+
+
+    @Query("""
+    SELECT s
+    FROM Subject s
+    WHERE (:code IS NULL OR :code = '' OR s.code = :code)
+      AND (:professorName IS NULL OR :professorName = '' 
+           OR LOWER(s.professorName) LIKE LOWER(CONCAT('%', :professorName, '%')))
+      AND (:subjectName IS NULL OR :subjectName = '' 
+           OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', :subjectName, '%')))
+    """)
+    Page<Subject> findAllByCodeAndProfessorNameAndSubjectName(@Param("code") String code,
+                                                              @Param("professorName") String professorName,
+                                                              @Param("subjectName") String subjectName,
+                                                              Pageable pageable);
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
@@ -42,6 +42,8 @@ public class SubjectQueryService {
         String professorName = nullIfBlank(filters.getProfessorName());
         String subjectName = nullIfBlank(filters.getSubjectName());
 
+
+
         Page<Subject> subjects
                 = subjectRepository.findAllByCodeAndProfessorNameAndSubjectName(code, professorName, subjectName, pageable);
 

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
@@ -1,0 +1,82 @@
+package com.practice.course_registration.domain.subject.service;
+
+import com.practice.course_registration.domain.member.domain.MemberEntity;
+import com.practice.course_registration.domain.member.repository.MemberRepository;
+import com.practice.course_registration.domain.subject.domain.MemberSubject;
+import com.practice.course_registration.domain.subject.domain.Subject;
+import com.practice.course_registration.domain.subject.dto.CourseFilterRequestDTO;
+import com.practice.course_registration.domain.subject.dto.SubjectResponseDTO;
+import com.practice.course_registration.domain.subject.repository.LikeSubjectRepository;
+import com.practice.course_registration.domain.subject.repository.MemberSubjectRepository;
+import com.practice.course_registration.domain.subject.repository.SubjectRepository;
+import com.practice.course_registration.global.apiPayload.code.status.ErrorStatus;
+import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class SubjectQueryService {
+
+    private final SubjectRepository subjectRepository;
+    private final MemberRepository memberRepository;
+    private final MemberSubjectRepository memberSubjectRepository;
+    private final LikeSubjectRepository likeSubjectRepository;
+
+    public Page<SubjectResponseDTO> searchAllSubject(Long memberId, CourseFilterRequestDTO filters, Pageable pageable) {
+
+        MemberEntity member = findById(memberId);
+
+        String code = nullIfBlank(filters.getCode());
+        String professorName = nullIfBlank(filters.getProfessorName());
+        String subjectName = nullIfBlank(filters.getSubjectName());
+
+        Page<Subject> subjects
+                = subjectRepository.findAllByCodeAndProfessorNameAndSubjectName(code, professorName, subjectName, pageable);
+
+        if (subjects.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        // 조건에 맞는 과목의 id 조회
+        List<Long> subjectIds = subjects.getContent().stream()
+                .map(Subject::getId)
+                .toList();
+
+        Set<Long> registeredIds = memberSubjectRepository.findAllByMemberAndSubject(member, subjectIds);
+        Set<Long> likedIds = likeSubjectRepository.findAllByMemberAndSubject(member, subjectIds);
+
+        return subjects.map(subject -> SubjectResponseDTO.builder()
+                .subjectName(subject.getSubjectName())
+                .professorName(subject.getProfessorName())
+                .limitedNum(subject.getLimitedNum())
+                .code(subject.getCode())
+                .subjectDay(subject.getSubjectDay())
+                .startTime(subject.getStartTime())
+                .endTime(subject.getEndTime())
+                .registered(registeredIds.contains(subject.getId()))
+                .liked(likedIds.contains(subject.getId()))
+                .build()
+        );
+    }
+
+    private MemberEntity findById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    private String nullIfBlank(String s) {
+        return (s == null || s.isBlank()) ? null : s.trim();
+    }
+
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
@@ -36,6 +36,7 @@ public class SubjectQueryService {
 
     public Page<SubjectResponseDTO> searchAllSubject(Long memberId, CourseFilterRequestDTO filters, Pageable pageable) {
 
+        log.info("===========search 시작==============");
         MemberEntity member = findById(memberId);
 
         String code = nullIfBlank(filters.getCode());
@@ -43,9 +44,10 @@ public class SubjectQueryService {
         String subjectName = nullIfBlank(filters.getSubjectName());
 
 
-
+        log.info("===========code: " + code + " =======professorName : " + professorName + " ========subjectName" + subjectName + " \n");
         Page<Subject> subjects
                 = subjectRepository.findAllByCodeAndProfessorNameAndSubjectName(code, professorName, subjectName, pageable);
+
 
         if (subjects.isEmpty()) {
             return Page.empty(pageable);
@@ -55,6 +57,7 @@ public class SubjectQueryService {
         List<Long> subjectIds = subjects.getContent().stream()
                 .map(Subject::getId)
                 .toList();
+        log.info("===========페이지 크기 : " + subjectIds.size());
 
         Set<Long> registeredIds = memberSubjectRepository.findAllByMemberAndSubject(member, subjectIds);
         Set<Long> likedIds = likeSubjectRepository.findAllByMemberAndSubject(member, subjectIds);

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
@@ -1,0 +1,13 @@
+package com.practice.course_registration.domain.subject.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class SubjectService {
+}

--- a/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 500번대
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
 
+    // member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "해당 멤버를 찾을 수 없습니다."),
 
 
     ;

--- a/src/main/resources/templates/courses/register-form.html
+++ b/src/main/resources/templates/courses/register-form.html
@@ -33,10 +33,10 @@
         <input type="text" name="code" th:value="${filters.code}" placeholder="예: AIX0002">
     </label>
     <label>교과명
-        <input type="text" name="name" th:value="${filters.subjectName}" placeholder="예: 자료구조">
+        <input type="text" name="subjectName" th:value="${filters.subjectName}" placeholder="예: 자료구조">
     </label>
     <label>교수명
-        <input type="text" name="professor" th:value="${filters.professorName}" placeholder="예: 홍길동">
+        <input type="text" name="professorName" th:value="${filters.professorName}" placeholder="예: 홍길동">
     </label>
     <button type="submit">조회</button>
 </form>
@@ -121,20 +121,20 @@
 <div class="pagination" th:if="${hasSearched and page.totalPages > 1}">
     <a th:if="${page.hasPrevious()}"
        th:href="@{/courses/search(page=${page.number-1}, size=${page.size},
-                                code=${filters.code}, name=${filters.subjectName}, professor=${filters.professorName})}">
+                                code=${filters.code}, subjectName=${filters.subjectName}, professorName=${filters.professorName})}">
         이전
     </a>
 
     <span th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
           th:classappend="${i == page.number} ? 'active'">
     <a th:href="@{/courses/search(page=${i}, size=${page.size},
-                                  code=${filters.code}, name=${filters.subjectName}, professor=${filters.professorName})}"
+                                  code=${filters.code}, subjectName=${filters.subjectName}, professorName=${filters.professorName})}"
        th:text="${i + 1}">1</a>
   </span>
 
     <a th:if="${page.hasNext()}"
        th:href="@{/courses/search(page=${page.number+1}, size=${page.size},
-                                code=${filters.code}, name=${filters.subjectName}, professor=${filters.professorName})}">
+                                code=${filters.code}, subjectName=${filters.subjectName}, professorName=${filters.professorName})}">
         다음
     </a>
 </div>

--- a/src/main/resources/templates/courses/register-form.html
+++ b/src/main/resources/templates/courses/register-form.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>수강신청</title>
+    <style>
+        body{font-family:system-ui,Roboto,Segoe UI,Apple SD Gothic Neo,Noto Sans KR,sans-serif;margin:20px;color:#1f2937}
+        h1{margin:0 0 16px;font-size:22px}
+        form.search{display:flex;gap:10px;flex-wrap:wrap;align-items:end;margin-bottom:12px}
+        label{display:flex;flex-direction:column;font-size:12px;color:#6b7280}
+        input[type="text"]{height:36px;border:1px solid #e5e7eb;border-radius:8px;padding:0 10px;min-width:180px}
+        button[type="submit"]{height:36px;border-radius:8px;border:1px solid #2563eb;background:#2563eb;color:#fff;padding:0 14px;cursor:pointer}
+        table{width:100%;border-collapse:collapse;margin-top:10px}
+        th,td{border:1px solid #e5e7eb;padding:10px;text-align:center;font-size:14px}
+        th{background:#f9fafb;color:#6b7280}
+        .btn{display:inline-block;height:30px;line-height:28px;padding:0 10px;border-radius:6px;border:1px solid #cbd5e1;background:#fff;cursor:pointer}
+        .btn-blue{border-color:#2563eb;background:#2563eb;color:#fff}
+        .btn-ghost{background:#fff}
+        .btn.disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
+        .pagination{margin-top:16px;text-align:center}
+        .pagination a,.pagination span{display:inline-block;margin:0 4px;padding:5px 10px;border:1px solid #e5e7eb;border-radius:6px;text-decoration:none;color:#374151}
+        .pagination .active{background:#eef2ff;border-color:#c7d2fe;font-weight:700}
+        .muted{color:#6b7280;font-size:12px}
+    </style>
+</head>
+<body>
+
+<h1>수강신청</h1>
+
+<!-- 🔎 필터: 결과 엔드포인트로 GET -->
+<form class="search" th:action="@{/courses/search}" method="get">
+    <label>학수번호
+        <input type="text" name="code" th:value="${filters.code}" placeholder="예: AIX0002">
+    </label>
+    <label>교과명
+        <input type="text" name="name" th:value="${filters.subjectName}" placeholder="예: 자료구조">
+    </label>
+    <label>교수명
+        <input type="text" name="professor" th:value="${filters.professorName}" placeholder="예: 홍길동">
+    </label>
+    <button type="submit">조회</button>
+</form>
+
+<!-- 건수: 검색 후에만 노출 -->
+<div class="muted" th:if="${hasSearched}"
+     th:text="'총 ' + ${page.totalElements} + '건 / ' + '페이지 ' + (${page.number + 1}) + ' / ' + ${page.totalPages}">
+    총 0건
+</div>
+
+<!-- 📋 결과 테이블: 검색 후에만 -->
+<table aria-label="과목 목록" th:if="${hasSearched}">
+    <thead>
+    <tr>
+        <th style="width:110px">수강신청</th>
+        <th style="width:110px">희망신청</th>
+        <th>교과명</th>
+        <th style="width:140px">교수명</th>
+        <th style="width:120px">제한인원</th>
+        <th style="width:140px">학수번호</th>
+        <th style="width:260px">수업 요일·시간</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="s : ${subjects}">
+        <!-- 수강신청 버튼(활성/비활성 토글) -->
+        <td>
+            <form th:action="@{/courses/apply}" method="post" style="display:inline">
+                <input type="hidden" name="_csrf" th:value="${_csrf?.token}">
+                <input type="hidden" name="code" th:value="${s.code}">
+                <button class="btn btn-blue" type="submit"
+                        th:disabled="${s.registered}" th:classappend="${s.registered} ? ' disabled'">
+                    신청
+                </button>
+            </form>
+            <form th:action="@{/courses/cancel}" method="post" style="display:inline;margin-left:6px">
+                <input type="hidden" name="_csrf" th:value="${_csrf?.token}">
+                <input type="hidden" name="code" th:value="${s.code}">
+                <button class="btn" type="submit"
+                        th:disabled="${!s.registered}" th:classappend="${!s.registered} ? ' disabled'">
+                    신청취소
+                </button>
+            </form>
+        </td>
+
+        <!-- 희망 버튼(활성/비활성 토글) -->
+        <td>
+            <form th:action="@{/courses/wish}" method="post" style="display:inline">
+                <input type="hidden" name="_csrf" th:value="${_csrf?.token}">
+                <input type="hidden" name="code" th:value="${s.code}">
+                <button class="btn btn-ghost" type="submit"
+                        th:disabled="${s.liked}" th:classappend="${s.liked} ? ' disabled'">
+                    희망추가
+                </button>
+            </form>
+            <form th:action="@{/courses/unwish}" method="post" style="display:inline;margin-left:6px">
+                <input type="hidden" name="_csrf" th:value="${_csrf?.token}">
+                <input type="hidden" name="code" th:value="${s.code}">
+                <button class="btn btn-ghost" type="submit"
+                        th:disabled="${!s.liked}" th:classappend="${!s.liked} ? ' disabled'">
+                    희망해제
+                </button>
+            </form>
+        </td>
+
+        <!-- 과목 정보 -->
+        <td th:text="${s.subjectName}">교과명</td>
+        <td th:text="${s.professorName}">홍길동</td>
+        <td th:text="${s.limitedNum}">30</td>
+        <td th:text="${s.code}">CS101</td>
+        <td th:text="${s.subjectDay + ' ' + s.startTime + ' ~ ' + s.endTime}">화 13:00 ~ 14:30</td>
+    </tr>
+
+    <!-- 빈 상태: 검색 후인데 결과가 없을 때만 -->
+    <tr th:if="${hasSearched and #lists.isEmpty(subjects)}">
+        <td colspan="7">조건에 맞는 과목이 없습니다.</td>
+    </tr>
+    </tbody>
+</table>
+
+<!-- 📑 페이징: 검색 후에만 -->
+<div class="pagination" th:if="${hasSearched and page.totalPages > 1}">
+    <a th:if="${page.hasPrevious()}"
+       th:href="@{/courses/search(page=${page.number-1}, size=${page.size},
+                                code=${filters.code}, name=${filters.subjectName}, professor=${filters.professorName})}">
+        이전
+    </a>
+
+    <span th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
+          th:classappend="${i == page.number} ? 'active'">
+    <a th:href="@{/courses/search(page=${i}, size=${page.size},
+                                  code=${filters.code}, name=${filters.subjectName}, professor=${filters.professorName})}"
+       th:text="${i + 1}">1</a>
+  </span>
+
+    <a th:if="${page.hasNext()}"
+       th:href="@{/courses/search(page=${page.number+1}, size=${page.size},
+                                code=${filters.code}, name=${filters.subjectName}, professor=${filters.professorName})}">
+        다음
+    </a>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## ❤️ 기능 설명
- 과목코드, 교과명, 교수명으로 필터링
- 테스트용으로 3개 단위로 페이징 처리

테스트 성공 결과 스크린샷 첨부

검색 없이 전체조회 -> 페이징처리
<img width="1626" height="782" alt="스크린샷 2025-08-31 012941" src="https://github.com/user-attachments/assets/d272086a-4f3b-4227-9e9a-b42a1ae53ead" />

교수명 검색
<img width="1624" height="637" alt="스크린샷 2025-08-31 012914" src="https://github.com/user-attachments/assets/6baa2f1f-5ae4-4fa8-8f33-8a00ff12c7e2" />

과목명 검색
<img width="1634" height="637" alt="스크린샷 2025-08-31 012927" src="https://github.com/user-attachments/assets/7172e3de-c0bb-4909-8292-2b9edfb08e7c" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #12 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!



<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
