### PR TITLE
[feat/#22] 신청내역 조회 및 수강취소 기능구현

### DIFF
--- a/src/main/java/com/practice/course_registration/domain/member/domain/Member.java
+++ b/src/main/java/com/practice/course_registration/domain/member/domain/Member.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/practice/course_registration/domain/subject/controller/MemberSubjectController.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/MemberSubjectController.java
@@ -1,0 +1,39 @@
+package com.practice.course_registration.domain.subject.controller;
+
+import com.practice.course_registration.domain.subject.dto.MyRegisteredSubjectResponseDTO;
+import com.practice.course_registration.domain.subject.dto.MySubjectResponseDTO;
+import com.practice.course_registration.domain.subject.dto.SubjectResponseDTO;
+import com.practice.course_registration.domain.subject.repository.MemberSubjectRepository;
+import com.practice.course_registration.domain.subject.service.SubjectQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/my")
+@Validated
+public class MemberSubjectController {
+
+    private final SubjectQueryService subjectQueryService;
+
+    @GetMapping("/courses")
+    public String myCourses(Model model) {
+
+        Long memberId = 1L;
+
+        List<MyRegisteredSubjectResponseDTO> subjects = subjectQueryService.searchMySubject(memberId);
+
+        model.addAttribute("applies", subjects);
+        model.addAttribute("activeTab", "applied");
+
+        return "courses/applied";
+
+    }
+
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/controller/MemberSubjectController.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/MemberSubjectController.java
@@ -5,12 +5,15 @@ import com.practice.course_registration.domain.subject.dto.MySubjectResponseDTO;
 import com.practice.course_registration.domain.subject.dto.SubjectResponseDTO;
 import com.practice.course_registration.domain.subject.repository.MemberSubjectRepository;
 import com.practice.course_registration.domain.subject.service.SubjectQueryService;
+import com.practice.course_registration.domain.subject.service.SubjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -21,6 +24,7 @@ import java.util.List;
 public class MemberSubjectController {
 
     private final SubjectQueryService subjectQueryService;
+    private final SubjectService subjectService;
 
     @GetMapping("/courses")
     public String myCourses(Model model) {
@@ -36,4 +40,13 @@ public class MemberSubjectController {
 
     }
 
+    @PostMapping("/cancel")
+    public String cancelCourses(@RequestParam Long subjectId) {
+
+        Long memberId = 1L;
+
+        subjectService.cancelCourse(memberId, subjectId);
+
+        return "redirect:/my/courses";
+    }
 }

--- a/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
@@ -48,7 +48,7 @@ public class SubjectContoller {
     @GetMapping("/search")
     public String search(CourseFilterRequestDTO filters,
                          Model model,
-                         @PageableDefault(size = 3, sort = "subjectName", direction = Sort.Direction.ASC) Pageable pageable) {
+                         @PageableDefault(size = 15, sort = "subjectName", direction = Sort.Direction.ASC) Pageable pageable) {
 
         Long memberId = 1L;
 

--- a/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
@@ -26,6 +26,8 @@ public class Subject extends BaseEntity {
 
     private Integer limitedNum; // 제한인원
 
+    private Integer registeredNum; // 현재신청인원
+
     private String code;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
@@ -4,6 +4,7 @@ import com.practice.course_registration.global.common.BaseEntity;
 import com.practice.course_registration.global.enums.SubjectDay;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ public class Subject extends BaseEntity {
 
     private Integer limitedNum; // 제한인원
 
+    @Column(nullable = false, columnDefinition = "int default 0")
     private Integer registeredNum; // 현재신청인원
 
     private String code;

--- a/src/main/java/com/practice/course_registration/domain/subject/dto/MyRegisteredSubjectResponseDTO.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/dto/MyRegisteredSubjectResponseDTO.java
@@ -9,6 +9,7 @@ import java.time.LocalTime;
 @Builder
 @Getter
 public class MyRegisteredSubjectResponseDTO {
+    private Long id;
 
     private String subjectName;
 

--- a/src/main/java/com/practice/course_registration/domain/subject/dto/MyRegisteredSubjectResponseDTO.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/dto/MyRegisteredSubjectResponseDTO.java
@@ -1,0 +1,27 @@
+package com.practice.course_registration.domain.subject.dto;
+
+import com.practice.course_registration.global.enums.SubjectDay;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class MyRegisteredSubjectResponseDTO {
+
+    private String subjectName;
+
+    private String professorName;
+
+    private Integer limitedNum; // 제한인원
+
+    private String code;
+
+    private SubjectDay subjectDay; // 수업 요일 (교양이라 하루만 한다는 전제)
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/dto/MySubjectResponseDTO.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/dto/MySubjectResponseDTO.java
@@ -1,0 +1,31 @@
+package com.practice.course_registration.domain.subject.dto;
+
+import com.practice.course_registration.global.enums.SubjectDay;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class MySubjectResponseDTO {
+
+    private String subjectName;
+
+    private String professorName;
+
+    private Integer limitedNum; // 제한인원
+
+    private String code;
+
+    private SubjectDay subjectDay; // 수업 요일 (교양이라 하루만 한다는 전제)
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    private Boolean registered;
+
+    private Boolean liked;
+
+}

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/MemberSubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/MemberSubjectRepository.java
@@ -4,6 +4,7 @@ import com.practice.course_registration.domain.member.domain.Member;
 import com.practice.course_registration.domain.subject.domain.MemberSubject;
 import com.practice.course_registration.domain.subject.domain.Subject;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,9 @@ public interface MemberSubjectRepository extends JpaRepository<MemberSubject, Lo
     Optional<MemberSubject> findByMemberAndSubject(Member member, Subject subject);
 
     List<MemberSubject> findAllByMember(Member member);
+
+    @Modifying
+    @Query("delete from MemberSubject ms where ms.member.id = :memberId and ms.subject.id = :subjectId")
+    void deleteByMemberIdAndSubjectId(@Param("memberId") Long memberId, @Param("subjectId") Long subjectId);
+
 }

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/MemberSubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/MemberSubjectRepository.java
@@ -18,7 +18,9 @@ public interface MemberSubjectRepository extends JpaRepository<MemberSubject, Lo
       FROM MemberSubject ms
       WHERE ms.member = :member AND ms.subject.id IN :subjectIds
     """)
-    Set<Long> findAllByMemberAndSubject(@Param("member") Member member, @Param("subjectIds") List<Long> subjectIds);
+    Set<Long> findAllIdByMemberAndSubject(@Param("member") Member member, @Param("subjectIds") List<Long> subjectIds);
 
     Optional<MemberSubject> findByMemberAndSubject(Member member, Subject subject);
+
+    List<MemberSubject> findAllByMember(Member member);
 }

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/SubjectRepository.java
@@ -4,6 +4,7 @@ import com.practice.course_registration.domain.subject.domain.Subject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +28,14 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                                                               Pageable pageable);
 
     Optional<Subject> findByCode(String code);
+
+
+    @Modifying
+    @Query("""
+        UPDATE Subject s
+        SET s.registeredNum = s.registeredNum + 1
+        WHERE s.id = :id
+        AND s.registeredNum < s.limitedNum
+    """)
+    int tryIncreaseRegistered(@Param("id") Long subjectId);
 }

--- a/src/main/java/com/practice/course_registration/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/repository/SubjectRepository.java
@@ -38,4 +38,13 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
         AND s.registeredNum < s.limitedNum
     """)
     int tryIncreaseRegistered(@Param("id") Long subjectId);
+
+    @Modifying
+    @Query("""
+        UPDATE Subject s
+        SET s.registeredNum = s.registeredNum - 1
+        WHERE s.id = :id
+        AND s.registeredNum < s.limitedNum
+    """)
+    int tryDecreaseRegistered(@Param("id") Long subjectId);
 }

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
@@ -87,6 +87,7 @@ public class SubjectQueryService {
         return memberSubjects.stream()
                 .map(MemberSubject::getSubject)
                 .map(subject -> MyRegisteredSubjectResponseDTO.builder()
+                        .id(subject.getId())
                         .subjectName(subject.getSubjectName())
                         .professorName(subject.getProfessorName())
                         .limitedNum(subject.getLimitedNum())

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectQueryService.java
@@ -5,6 +5,8 @@ import com.practice.course_registration.domain.member.repository.MemberRepositor
 import com.practice.course_registration.domain.subject.domain.MemberSubject;
 import com.practice.course_registration.domain.subject.domain.Subject;
 import com.practice.course_registration.domain.subject.dto.CourseFilterRequestDTO;
+import com.practice.course_registration.domain.subject.dto.MyRegisteredSubjectResponseDTO;
+import com.practice.course_registration.domain.subject.dto.MySubjectResponseDTO;
 import com.practice.course_registration.domain.subject.dto.SubjectResponseDTO;
 import com.practice.course_registration.domain.subject.repository.LikeSubjectRepository;
 import com.practice.course_registration.domain.subject.repository.MemberSubjectRepository;
@@ -22,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -59,7 +62,7 @@ public class SubjectQueryService {
                 .toList();
         log.info("===========페이지 크기 : " + subjectIds.size());
 
-        Set<Long> registeredIds = memberSubjectRepository.findAllByMemberAndSubject(member, subjectIds);
+        Set<Long> registeredIds = memberSubjectRepository.findAllIdByMemberAndSubject(member, subjectIds);
         Set<Long> likedIds = likeSubjectRepository.findAllByMemberAndSubject(member, subjectIds);
 
         return subjects.map(subject -> SubjectResponseDTO.builder()
@@ -74,6 +77,26 @@ public class SubjectQueryService {
                 .liked(likedIds.contains(subject.getId()))
                 .build()
         );
+    }
+
+    public List<MyRegisteredSubjectResponseDTO> searchMySubject(Long memberId) {
+
+        Member member = findById(memberId);
+
+        List<MemberSubject> memberSubjects = memberSubjectRepository.findAllByMember(member);
+        return memberSubjects.stream()
+                .map(MemberSubject::getSubject)
+                .map(subject -> MyRegisteredSubjectResponseDTO.builder()
+                        .subjectName(subject.getSubjectName())
+                        .professorName(subject.getProfessorName())
+                        .limitedNum(subject.getLimitedNum())
+                        .code(subject.getCode())
+                        .subjectDay(subject.getSubjectDay())
+                        .startTime(subject.getStartTime())
+                        .endTime(subject.getEndTime())
+                        .build()
+                )
+                .collect(Collectors.toList());
     }
 
     private Member findById(Long memberId) {

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
@@ -27,18 +27,20 @@ public class SubjectService {
     private final MemberRepository memberRepository;
 
 
+    // 수강신청
     public void applyCourse(Long memberId, String code) {
         // 멤버 찾기
         Member member = findById(memberId);
 
         // 해당 과목 찾기
         Subject subject = findByCode(code);
-
         /*
         * 예외처리
         * - 이미 신청된 경우
         * - 신청한 과목과 같은 시간의 과목인 경우
         * - 과목코드가 같은 경우
+        * - 과목제한인원이 초과된 경우
+        * - 신청가능학점을 넘긴경우
         * */
         if (memberSubjectRepository.findByMemberAndSubject(member, subject).isPresent()) {
             throw new ErrorHandler(ErrorStatus.ALREADY_APPLY_SUBJECT);
@@ -71,6 +73,12 @@ public class SubjectService {
             throw new ErrorHandler(ErrorStatus.ALREADY_APPLY_SUBJECT);
         }
 
+        int result = subjectRepository.tryIncreaseRegistered(subject.getId());
+
+        if (result == 0) {
+            log.error("제한인원 초과");
+            throw new ErrorHandler(ErrorStatus.CAPACITY_FULL);
+        }
 
         // 저장
         MemberSubject memberSubject = MemberSubject.builder()

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
@@ -30,7 +30,7 @@ public class SubjectService {
     // 수강신청
     public void applyCourse(Long memberId, String code) {
         // 멤버 찾기
-        Member member = findById(memberId);
+        Member member = findMemberById(memberId);
 
         // 해당 과목 찾기
         Subject subject = findByCode(code);
@@ -76,9 +76,10 @@ public class SubjectService {
         int result = subjectRepository.tryIncreaseRegistered(subject.getId());
 
         if (result == 0) {
-            log.error("제한인원 초과");
+            log.error("제한인원 초과, 제한인원 : " + subject.getLimitedNum() + " , 신청인원 : " + subject.getRegisteredNum());
             throw new ErrorHandler(ErrorStatus.CAPACITY_FULL);
         }
+
 
         // 저장
         MemberSubject memberSubject = MemberSubject.builder()
@@ -92,7 +93,32 @@ public class SubjectService {
 
     }
 
-    private Member findById(Long memberId) {
+
+    // 수강취소
+    public void cancelCourse(Long memberId, Long subjectId) {
+
+        // 멤버 찾기
+        Member member = findMemberById(memberId);
+
+        // 해당 과목 찾기
+        Subject subject = findSubjectById(subjectId);
+
+        MemberSubject memberSubject = memberSubjectRepository.findByMemberAndSubject(member, subject)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.NOT_APPLY_SUBJECT));
+
+
+        memberSubjectRepository.deleteByMemberIdAndSubjectId(memberId, subjectId);
+        subjectRepository.tryDecreaseRegistered(subjectId);
+    }
+
+
+    private Subject findSubjectById(Long subjectId) {
+        return subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.SUBJECT_NOT_FOUND));
+    }
+
+
+    private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     SUBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBJECT4001", "해당 과목을 찾을 수 없습니다."),
     ALREADY_APPLY_SUBJECT(HttpStatus.BAD_REQUEST, "SUBJECT4002", "이미 신청한 과목입니다."),
     CONFLICT_COURSE_TIME(HttpStatus.BAD_REQUEST, "SUBJECT4003", "동일한 시간대에 신청한 과목이 있습니다."),
+    CAPACITY_FULL(HttpStatus.BAD_REQUEST, "SUBJECT4004", "제한 인원이 가득 찼습니다.")
 
     ;
 

--- a/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
@@ -29,8 +29,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // subject
     SUBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBJECT4001", "해당 과목을 찾을 수 없습니다."),
     ALREADY_APPLY_SUBJECT(HttpStatus.BAD_REQUEST, "SUBJECT4002", "이미 신청한 과목입니다."),
-    CONFLICT_COURSE_TIME(HttpStatus.BAD_REQUEST, "SUBJECT4003", "동일한 시간대에 신청한 과목이 있습니다."),
-    CAPACITY_FULL(HttpStatus.BAD_REQUEST, "SUBJECT4004", "제한 인원이 가득 찼습니다.")
+    NOT_APPLY_SUBJECT(HttpStatus.BAD_REQUEST, "SUBJECT4003", "해당 과목을 신청하지 않았습니다."),
+    CONFLICT_COURSE_TIME(HttpStatus.BAD_REQUEST, "SUBJECT4004", "동일한 시간대에 신청한 과목이 있습니다."),
+    CAPACITY_FULL(HttpStatus.BAD_REQUEST, "SUBJECT4005", "제한 인원이 가득 찼습니다.")
 
     ;
 

--- a/src/main/resources/templates/courses/applied.html
+++ b/src/main/resources/templates/courses/applied.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>신청내역</title>
+    <style>
+        body{font-family:system-ui,Roboto,Segoe UI,Apple SD Gothic Neo,Noto Sans KR,sans-serif;margin:20px;color:#1f2937}
+        h1{margin:0 0 16px;font-size:22px}
+        form.search{display:flex;gap:10px;flex-wrap:wrap;align-items:end;margin-bottom:12px}
+        label{display:flex;flex-direction:column;font-size:12px;color:#6b7280}
+        input[type="text"]{height:36px;border:1px solid #e5e7eb;border-radius:8px;padding:0 10px;min-width:180px}
+        button[type="submit"]{height:36px;border-radius:8px;border:1px solid #2563eb;background:#2563eb;color:#fff;padding:0 14px;cursor:pointer}
+        table{width:100%;border-collapse:collapse;margin-top:10px}
+        th,td{border:1px solid #e5e7eb;padding:10px;text-align:center;font-size:14px}
+        th{background:#f9fafb;color:#6b7280}
+        .btn{display:inline-block;height:30px;line-height:28px;padding:0 10px;border-radius:6px;border:1px solid #cbd5e1;background:#fff;cursor:pointer}
+        .btn-blue{border-color:#2563eb;background:#2563eb;color:#fff}
+        .btn-ghost{background:#fff}
+        .btn-danger{border-color:#ef4444;background:#ef4444;color:#fff}
+        .btn.disabled,.btn:disabled{opacity:.5;cursor:not-allowed}
+        .pagination{margin-top:16px;text-align:center}
+        .pagination a,.pagination span{display:inline-block;margin:0 4px;padding:5px 10px;border:1px solid #e5e7eb;border-radius:6px;text-decoration:none;color:#374151}
+        .pagination .active{background:#eef2ff;border-color:#c7d2fe;font-weight:700}
+        .muted{color:#6b7280;font-size:12px}
+        .status{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px}
+        .status-approved{background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0}
+        .status-pending{background:#fffbeb;color:#92400e;border:1px solid #fde68a}
+        .status-rejected{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}
+    </style>
+</head>
+<body>
+
+<h1>신청내역</h1>
+
+<!-- 탭 네비게이션 (그대로 유지) -->
+<nav class="tabs">
+    <a th:href="@{/courses}"
+       th:classappend="${activeTab}=='register' ? ' active'">수강신청</a>
+    <a th:href="@{/my/courses}"
+       th:classappend="${activeTab}=='applied' ? ' active'">신청내역</a>
+    <a th:href="@{/courses/wishlist}"
+       th:classappend="${activeTab}=='wishlist' ? ' active'">희망수업</a>
+</nav>
+
+<style>
+    .tabs{display:flex;gap:10px;margin:14px 0;border-bottom:1px solid #e5e7eb}
+    .tabs a{padding:10px 14px;border:1px solid transparent;border-bottom:none;
+        border-top-left-radius:8px;border-top-right-radius:8px;
+        color:#374151;text-decoration:none}
+    .tabs a:hover{background:#f9fafb}
+    .tabs a.active{background:#fff;border-color:#e5e7eb;border-bottom:1px solid #fff;
+        font-weight:700}
+</style>
+
+
+<!-- 건수 -->
+<div class="muted"
+     th:if="${page != null}"
+     th:text="'총 ' + ${page.totalElements} + '건 / ' + '페이지 ' + (${page.number + 1}) + ' / ' + ${page.totalPages}">
+    총 0건
+</div>
+
+<!-- 📋 신청내역 테이블 -->
+<table aria-label="신청 과목 목록" th:if="${applies != null}">
+    <thead>
+    <tr>
+        <th style="width:110px">신청취소</th>
+        <th>교과명</th>
+        <th style="width:140px">교수명</th>
+        <th style="width:120px">학수번호</th>
+        <th style="width:220px">수업 요일·시간</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="a : ${applies}">
+        <!-- 항상 활성화된 취소 버튼 -->
+        <td>
+            <form th:action="@{/courses/cancel}" method="post" style="display:inline">
+                <input type="hidden" name="_csrf" th:value="${_csrf?.token}">
+                <input type="hidden" name="code" th:value="${a.code}">
+                <button class="btn btn-danger" type="submit">신청취소</button>
+            </form>
+        </td>
+
+        <td th:text="${a.subjectName}">교과명</td>
+        <td th:text="${a.professorName}">홍길동</td>
+        <td th:text="${a.code}">CS101</td>
+        <td th:text="${a.subjectDay + ' ' + a.startTime + ' ~ ' + a.endTime}">화 13:00 ~ 14:30</td>
+    </tr>
+
+    <!-- 빈 상태 -->
+    <tr th:if="${#lists.isEmpty(applies)}">
+        <td colspan="5">신청한 과목이 없습니다.</td>
+    </tr>
+    </tbody>
+</table>
+
+<!-- 메시지 알림 -->
+<script th:if="${message}" th:inline="javascript">
+    alert([[${message}]]);
+</script>
+
+<script th:if="${errorMessage}" th:inline="javascript">
+    alert([[${errorMessage}]]);
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/courses/applied.html
+++ b/src/main/resources/templates/courses/applied.html
@@ -75,9 +75,9 @@
     <tr th:each="a : ${applies}">
         <!-- 항상 활성화된 취소 버튼 -->
         <td>
-            <form th:action="@{/courses/cancel}" method="post" style="display:inline">
+            <form th:action="@{/my/cancel}" method="post" style="display:inline">
                 <input type="hidden" name="_csrf" th:value="${_csrf?.token}">
-                <input type="hidden" name="code" th:value="${a.code}">
+                <input type="hidden" name="subjectId" th:value="${a.id}">
                 <button class="btn btn-danger" type="submit">신청취소</button>
             </form>
         </td>

--- a/src/main/resources/templates/courses/register-form.html
+++ b/src/main/resources/templates/courses/register-form.html
@@ -31,7 +31,7 @@
 <nav class="tabs">
     <a th:href="@{/courses}"
        th:classappend="${activeTab}=='register' ? ' active'">수강신청</a>
-    <a th:href="@{/courses/applied}"
+    <a th:href="@{/my/courses}"
        th:classappend="${activeTab}=='applied' ? ' active'">신청내역</a>
     <a th:href="@{/courses/wishlist}"
        th:classappend="${activeTab}=='wishlist' ? ' active'">희망수업</a>


### PR DESCRIPTION
## ❤️ 기능 설명
- 신청한 과목 조회기능
- 신청한 과목을 수강 취소하는 기능 구현

테스트 성공 결과 스크린샷 첨부

신청내역 페이지
<img width="2010" height="737" alt="스크린샷 2025-09-15 184819" src="https://github.com/user-attachments/assets/8bb83e95-6046-436b-be92-965ee0229fb1" />


수강취소
<img width="1873" height="414" alt="image" src="https://github.com/user-attachments/assets/074b0621-0755-4dd7-8289-bed33d79e6d4" />



<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #22 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 신청 후 리다이렉트 부분 조금 수정할 필요는 있을 거 같은데, 전체 로직은 일단 구현되어서 올릴게여


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
