### PR TITLE
[fix/#27] 리다이렉트 등 자잘한 요소 수정

### DIFF
--- a/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
@@ -77,6 +77,6 @@ public class SubjectContoller {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
         }
 
-        return "redirect:/courses";
+        return "redirect:/courses/search";
     }
 }

--- a/src/main/java/com/practice/course_registration/global/config/SecurityConfig.java
+++ b/src/main/java/com/practice/course_registration/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
         http
                 .formLogin((form) -> form
                         .loginPage("/login") // 로그인 성공 시 redirect url 추후 작성
-                        .defaultSuccessUrl("/courses")
+                        .defaultSuccessUrl("/courses", true)
                         .failureUrl("/login?error=true")
                         .permitAll()
                 );

--- a/src/main/resources/templates/courses/register-form.html
+++ b/src/main/resources/templates/courses/register-form.html
@@ -49,7 +49,7 @@
 
 
 <!-- 🔎 필터: 결과 엔드포인트로 GET -->
-<form class="search" th:action="@{/courses/search}" method="get">
+<form class="search" th:action="@{/courses/search}" method="get" th:if="${activeTab != 'wishlist'}">
     <label>학수번호
         <input type="text" name="code" th:value="${filters.code}" placeholder="예: AIX0002">
     </label>


### PR DESCRIPTION
## ❤️ 기능 설명
- 로그인 > 메인 리다이렉트
- 수강신청시 직전화면 그대로 리다이렉트
- 희망수업 검색쪽 제거


테스트 성공 결과 스크린샷 첨부

희망수업 검색기능 제거
<img width="2559" height="793" alt="스크린샷 2025-09-24 092224" src="https://github.com/user-attachments/assets/cf10361d-6378-4bde-8657-2ac31afb2575" />

수강신청시 직전 화면 그대로 리다이렉트
<img width="2555" height="1110" alt="스크린샷 2025-09-24 092244" src="https://github.com/user-attachments/assets/1023d8c0-f0d4-4667-84c1-28638e1ab33a" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #27 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 지금 봤는데 희망수업쪽 title이 수강신청으로 되어있네요... 그냥 수강신청과 희망수업의 html을 분리하는게 어떨까요??
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
