### PR TITLE
feat/#40: 카프카 브로커 3개로 증가

### DIFF
--- a/src/main/java/com/practice/course_registration/global/config/KafkaProducerConfig.java
+++ b/src/main/java/com/practice/course_registration/global/config/KafkaProducerConfig.java
@@ -1,0 +1,44 @@
+package com.practice.course_registration.global.config;
+
+import com.practice.course_registration.global.kafka.RegistrationMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@Slf4j
+public class KafkaProducerConfig {
+    @Bean
+    public ProducerFactory<String, RegistrationMessage> producerFactory(){
+        return new DefaultKafkaProducerFactory<>(producerConfigs());
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigs(){
+        // configs 안에 다양한 타입이 들어가기 때문에, Object를 통해 모두 담는다.
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:29092,localhost:29093,localhost:29094");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+
+        return props;
+    }
+
+    @Bean
+    public KafkaTemplate<String, RegistrationMessage> kafkaTemplate(){
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/practice/course_registration/global/kafka/KafkaProducer.java
+++ b/src/main/java/com/practice/course_registration/global/kafka/KafkaProducer.java
@@ -2,9 +2,11 @@ package com.practice.course_registration.global.kafka;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Component
 @Slf4j
@@ -25,7 +27,23 @@ public class KafkaProducer {
                 requestId
         );
 
-        // 카프카로 전송한다.
-        kafkaTemplate.send("registration-queue", subjectCode, message);
+        // 비동기로 카프카에 전송
+        CompletableFuture<SendResult<String, RegistrationMessage>> future =
+                kafkaTemplate.send("registration-queue", subjectCode, message);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null){
+                log.info("메시지 전송 성공 - requestId: {}, topic: {}, partition: {}, offset: {}",
+                        requestId,
+                        result.getRecordMetadata().topic(),
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+            }
+            else {
+                log.error("메시지 전송 실패 - requestId: {}, userId: {}, subjectCode: {}, error: {}",
+                        requestId, userId, subjectCode, ex.getMessage());
+            }
+        });
+
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
- 기존에 application.yml에 설정을 넣어놨었는데, Kafka 관련 설정이 추가될 경우를 대비해서 최대한 공식문서 참고하면서 `KafkaProdcuerConfig` 파일을 생성하였습니다.
- 브로커가 1개면은 나중에 replication이나, partition을 늘렸을 때 오류가 생길 수도 있고, 동시성 처리를 하는 데에도 느릴 것이라고 생각해서, 3개로 증가시켰습니다.
- 나머지 설정은 아직 바꾸지 않았습니다. (파티션을 늘리더라도 Consumer 코드에서 핵심 로직은 안 변한다고 하네요)

테스트 성공 결과 스크린샷 첨부
<img width="1682" height="317" alt="image" src="https://github.com/user-attachments/assets/0b1701c4-5a1e-4743-a69f-989254fbf07d" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #40 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] docker-compose.yml 파일 수정하였으니 노션에 올려두겠습니다~!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
