### PR TITLE
fix: 기존 springboot의 배포 과정을 docker-compose로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,22 +45,19 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
-            # 기존 컨테이너 중지 및 제거
-            sudo docker stop $(sudo docker ps -q --filter ancestor=${{ secrets.DOCKER_USERNAME }}/docker-springboot) || true
-            sudo docker rm $(sudo docker ps -aq --filter ancestor=${{ secrets.DOCKER_USERNAME }}/docker-springboot) || true
+            export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
+            export EC2_PRIVATE_IP=${{ secrets.EC2_PRIVATE_IP }}
+            export SPRING_PROFILES_ACTIVE=prod
+            export DB_HOST=${{ secrets.DB_HOST }}
+            export DB_PORT=${{ secrets.DB_PORT }}
+            export DB_NAME=${{ secrets.DB_NAME }}
+            export DB_USERNAME=${{ secrets.DB_USERNAME }}
+            export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
 
-            # 새 이미지 pull
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/docker-springboot
+            # 이미지 최신화 및 컨테이너 재시작
+            sudo docker-compose pull
+            sudo docker-compose down
+            sudo docker-compose up -d --remove-orphans
 
-            # 새 컨테이너 실행
-            sudo docker run -d -p 80:8080 \
-              -e SPRING_PROFILES_ACTIVE=prod \
-              -e DB_HOST=${{ secrets.DB_HOST }} \
-              -e DB_PORT=${{ secrets.DB_PORT }} \
-              -e DB_NAME=${{ secrets.DB_NAME }} \
-              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
-              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-              ${{ secrets.DOCKER_USERNAME }}/docker-springboot:latest
-
-            # 이미지 정리
+            # 필요 없는 이미지 정리
             sudo docker image prune -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           --health-cmd "redis-cli ping || exit 1"
           --health-interval 5s --health-timeout 3s --health-retries 10
 
-
     steps:
       - uses: actions/checkout@v3
 
@@ -30,4 +29,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run tests
-        run: ./gradlew test --stacktrace --info
+        run: ./gradlew test --stacktrace --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run tests
-        run: ./gradlew test --stacktrace --no-daemon
+        run: ./gradlew test --stacktrace --info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,7 @@ jobs:
         options: >-
           --health-cmd "redis-cli ping || exit 1"
           --health-interval 5s --health-timeout 3s --health-retries 10
-      # Kafka
-      kafka:
-        image: confluentinc/cp-kafka:latest
-        ports:
-          - 9092:9092
-        env:
-          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-          KAFKA_BROKER_ID: 1
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-    
+
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,23 @@ jobs:
         options: >-
           --health-cmd "redis-cli ping || exit 1"
           --health-interval 5s --health-timeout 3s --health-retries 10
+      # Kafka
+      kafka:
+        image: confluentinc/cp-kafka:latest
+        ports:
+          - 9092:9092
+        env:
+          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_BROKER_ID: 1
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+        options: >-
+          --health-cmd "kafka-topics --bootstrap-server localhost:9092 --list || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+    
 
     steps:
       - uses: actions/checkout@v3
@@ -27,14 +44,6 @@ jobs:
 
       - name: Grant permission for gradlew
         run: chmod +x gradlew
-
-      - name: Set environment variables
-        run: |
-          echo "DB_HOST=${{ secrets.DB_HOST }}" >> $GITHUB_ENV
-          echo "DB_PORT=${{ secrets.DB_PORT }}" >> $GITHUB_ENV
-          echo "DB_NAME=${{ secrets.DB_NAME }}" >> $GITHUB_ENV
-          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> $GITHUB_ENV
-          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> $GITHUB_ENV
 
       - name: Run tests
         run: ./gradlew test --stacktrace --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ jobs:
           KAFKA_BROKER_ID: 1
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-        options: >-
-          --health-cmd "kafka-topics --bootstrap-server localhost:9092 --list || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 12
     
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,13 @@ jobs:
       - name: Grant permission for gradlew
         run: chmod +x gradlew
 
+      - name: Set environment variables
+        run: |
+          echo "DB_HOST=${{ secrets.DB_HOST }}" >> $GITHUB_ENV
+          echo "DB_PORT=${{ secrets.DB_PORT }}" >> $GITHUB_ENV
+          echo "DB_NAME=${{ secrets.DB_NAME }}" >> $GITHUB_ENV
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> $GITHUB_ENV
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> $GITHUB_ENV
+
       - name: Run tests
         run: ./gradlew test --stacktrace --no-daemon

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 
 	// kafka
 	implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.kafka:spring-kafka-test'
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,130 @@
+services:
+  kafka-1:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka-1
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka-1:9092,CONTROLLER://kafka-1:9093,PLAINTEXT_HOST://0.0.0.0:29092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka-1:9092,PLAINTEXT_HOST://${EC2_PRIVATE_IP}:29092'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      CLUSTER_ID: 'ciWo7IWazngRchmPES6q5A=='
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+    networks:
+      - app-network
+
+  kafka-2:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka-2
+    ports:
+      - "29093:29093"
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka-2:9092,CONTROLLER://kafka-2:9093,PLAINTEXT_HOST://0.0.0.0:29093'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka-2:9092,PLAINTEXT_HOST://${EC2_PRIVATE_IP}:29093'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      CLUSTER_ID: 'ciWo7IWazngRchmPES6q5A=='
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+    networks:
+      - app-network
+
+  kafka-3:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka-3
+    ports:
+      - "29094:29094"
+    environment:
+      KAFKA_NODE_ID: 3
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka-3:9092,CONTROLLER://kafka-3:9093,PLAINTEXT_HOST://0.0.0.0:29094'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka-3:9092,PLAINTEXT_HOST://${EC2_PRIVATE_IP}:29094'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      CLUSTER_ID: 'ciWo7IWazngRchmPES6q5A=='
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+    networks:
+      - app-network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "8090:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka-1:9092,kafka-2:9092,kafka-3:9092
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+    networks:
+      - app-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    command: [ "redis-server", "--appendonly", "yes" ]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - app-network
+
+  app:
+    image: ${DOCKER_USERNAME}/docker-springboot:latest
+    container_name: springboot-app
+    ports:
+      - "80:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka-1:9092,kafka-2:9092,kafka-3:9092
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka-1:
+        condition: service_started
+      kafka-2:
+        condition: service_started
+      kafka-3:
+        condition: service_started
+    restart: unless-stopped
+    networks:
+      - app-network
+
+volumes:
+  redis-data:
+
+networks:
+  app-network:
+    driver: bridge

--- a/src/main/java/com/practice/course_registration/global/config/KafkaProducerConfig.java
+++ b/src/main/java/com/practice/course_registration/global/config/KafkaProducerConfig.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
@@ -19,6 +20,9 @@ import java.util.Map;
 @Configuration
 @Slf4j
 public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
     @Bean
     public ProducerFactory<String, RegistrationMessage> producerFactory(){
         return new DefaultKafkaProducerFactory<>(producerConfigs());
@@ -28,7 +32,7 @@ public class KafkaProducerConfig {
     public Map<String, Object> producerConfigs(){
         // configs 안에 다양한 타입이 들어가기 때문에, Object를 통해 모두 담는다.
         Map<String, Object> props = new HashMap<>();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:29092,localhost:29093,localhost:29094");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.ACKS_CONFIG, "all");

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -33,6 +33,9 @@ spring:
     resources:
       add-mappings: false
 
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS}
+
 server:
   servlet:
     session:

--- a/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
+++ b/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
@@ -1,12 +1,23 @@
 package com.practice.course_registration;
 
+import com.practice.course_registration.global.kafka.KafkaProducer;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 
-@SpringBootTest(properties = "spring.kafka.enabled=false")
+@SpringBootTest
 class CourseRegistrationApplicationTests {
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public KafkaProducer kafkaProducer() {
+            // 실제 KafkaTemplate 등 의존을 가진 KafkaProducer를 Mockito로 대체
+            return Mockito.mock(KafkaProducer.class);
+        }
+        // 필요한 경우 KafkaTemplate 같은 다른 빈들도 여기서 mock으로 등록
+    }
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
+++ b/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
@@ -6,19 +6,13 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class CourseRegistrationApplicationTests {
-    @TestConfiguration
-    static class TestConfig {
-        @Bean
-        public KafkaProducer kafkaProducer() {
-            // 실제 KafkaTemplate 등 의존을 가진 KafkaProducer를 Mockito로 대체
-            return Mockito.mock(KafkaProducer.class);
-        }
-        // 필요한 경우 KafkaTemplate 같은 다른 빈들도 여기서 mock으로 등록
-    }
-
+    @MockitoBean
+    private KafkaProducer kafkaProducer;
 	@Test
 	void contextLoads() {
 	}

--- a/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
+++ b/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
@@ -5,8 +5,7 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-@ImportAutoConfiguration(exclude = KafkaAutoConfiguration.class)
+@SpringBootTest(properties = "spring.kafka.enabled=false")
 class CourseRegistrationApplicationTests {
 
 	@Test

--- a/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
+++ b/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
@@ -7,14 +7,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
+@EmbeddedKafka(partitions = 1, brokerProperties = {"listeners=PLAINTEXT://localhost:9092",
+        "port=9092"})
 class CourseRegistrationApplicationTests {
-    @MockitoBean
-    private KafkaProducer kafkaProducer;
 	@Test
 	void contextLoads() {
 	}
-
 }

--- a/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
+++ b/src/test/java/com/practice/course_registration/CourseRegistrationApplicationTests.java
@@ -1,9 +1,12 @@
 package com.practice.course_registration;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@ImportAutoConfiguration(exclude = KafkaAutoConfiguration.class)
 class CourseRegistrationApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 
- 이전에 SpringBoot는 따로 배포하는 과정을 docker-compose에 합쳐서 cd 과정을 간소화하였습니다.
- contextload에서 계속해서 kafka 관련 오류가 났었는데, @EmbeddedKafka를 통해서 테스트 시에는 내부 Kafka를 사용하도록 하였더니 문제가 해결된 것 같습니다.
- kafka관련해서 prod 환경이랑 local 환경에서 약간의 차이가 나서 파일을 각각 만들었습니다.
- 같은 이유로, application도 local하고, prod로 나눴고, application.yml에서 활성화할 수 있도록 약간의 수정을 하였습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #43  
<br>
<br>

## ✅ Approve 시 확인 사항

- [ ] spring docker-compose 이렇게 써도 되는지 확인 한 번만 해주세요!
- [ ] yml 파일을 prod와 local로 이렇게 나누는 게 맞는지 확인 한 번만 해주세요

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
