### PR TITLE
[feat/#48] Redis를 이용한 rete limit, 멱등키 구현

### DIFF
--- a/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectContoller.java
@@ -31,6 +31,7 @@ public class SubjectContoller {
 
     private final SubjectQueryService subjectQueryService;
     private final KafkaProducer kafkaProducer;
+//    private final SubjectService subjectService;
 
 
     /*

--- a/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/domain/Subject.java
@@ -30,6 +30,7 @@ public class Subject extends BaseEntity {
     @Column(nullable = false, columnDefinition = "int default 0")
     private Integer registeredNum; // 현재신청인원
 
+    @Column(unique = true)
     private String code;
 
     @Column(nullable = false)

--- a/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/service/SubjectService.java
@@ -8,8 +8,11 @@ import com.practice.course_registration.domain.subject.repository.MemberSubjectR
 import com.practice.course_registration.domain.subject.repository.SubjectRepository;
 import com.practice.course_registration.global.apiPayload.code.status.ErrorStatus;
 import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
+import com.practice.course_registration.global.redis.service.IdempotencyService;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,78 +28,103 @@ public class SubjectService {
     private final SubjectRepository subjectRepository;
     private final MemberSubjectRepository memberSubjectRepository;
     private final MemberRepository memberRepository;
+    private final IdempotencyService idempotencyService;
+
     private static final int MAX_SCORE = 10;
+    private static final String APPLY_RATE_LIMIT_KEY_PREFIX = "apply:";
+    private static final int RATE_LIMIT_CNT = 5;
+    private static final int RATE_LIMIT_TTL = 1;
+    private static final int IDEM_KEY_TTL = 15;
 
     // 수강신청
+    /*
+     * 예외처리
+     * - 이미 신청된 경우
+     * - 신청한 과목과 같은 시간의 과목인 경우
+     * - 과목코드가 같은 경우
+     * - 과목제한인원이 초과된 경우
+     * - 신청가능학점을 넘긴경우
+     * */
     public void applyCourse(Long memberId, String code) {
-        // 멤버 찾기
-        Member member = findMemberById(memberId);
-
-        // 해당 과목 찾기
-        Subject subject = findByCode(code);
-        /*
-        * 예외처리
-        * - 이미 신청된 경우
-        * - 신청한 과목과 같은 시간의 과목인 경우
-        * - 과목코드가 같은 경우
-        * - 과목제한인원이 초과된 경우
-        * - 신청가능학점을 넘긴경우
-        * */
-        if (memberSubjectRepository.findByMemberAndSubject(member, subject).isPresent()) {
-            throw new ErrorHandler(ErrorStatus.ALREADY_APPLY_SUBJECT);
+        // 입구 제어 (초 당 너무 많은 신청을 보내는지 제어)
+        if (!idempotencyService.rateLimitAllow(APPLY_RATE_LIMIT_KEY_PREFIX + memberId, RATE_LIMIT_CNT, Duration.ofSeconds(RATE_LIMIT_TTL))) {
+            throw new ErrorHandler(ErrorStatus.TOO_MANY_REQUESTS);
         }
 
-        if (member.getRegisteredScore() + subject.getScore() > MAX_SCORE) {
-            throw new ErrorHandler(ErrorStatus.OVER_SOCRE_POSSIBLE);
+        // 멱등키 획득 -> 중복클릭 방지
+        if (!idempotencyService.acquireIdempotency(memberId, code, Duration.ofSeconds(IDEM_KEY_TTL))) {
+            throw new ErrorHandler(ErrorStatus.DUPLICATE_REQUEST);
         }
 
-        boolean conflict = member.getMemberSubjects().stream()
-                .map(MemberSubject::getSubject)
-                .filter(subj ->
-                        subj.getSubjectDay() == subject.getSubjectDay()
-                )
-                .anyMatch(subj -> subj.conflictCheck(subject))
-        ;
+        try {
+            // 멤버 찾기
+            Member member = findMemberById(memberId);
 
-        int isSameCode = member.getMemberSubjects().stream()
-                .map(MemberSubject::getSubject)
-                .filter(subj ->
-                        subj.getCode().equals(subject.getCode())
-                )
-                .toList()
-                .size()
-        ;
+            // 해당 과목 찾기
+            Subject subject = findByCode(code);
 
-        if (conflict) {
-            log.error("시간 충돌");
-            throw new ErrorHandler(ErrorStatus.CONFLICT_COURSE_TIME);
+            if (memberSubjectRepository.findByMemberAndSubject(member, subject).isPresent()) {
+                throw new ErrorHandler(ErrorStatus.ALREADY_APPLY_SUBJECT);
+            }
+
+            if (member.getRegisteredScore() + subject.getScore() > MAX_SCORE) {
+                throw new ErrorHandler(ErrorStatus.OVER_SOCRE_POSSIBLE);
+            }
+
+            boolean conflict = member.getMemberSubjects().stream()
+                    .map(MemberSubject::getSubject)
+                    .filter(subj ->
+                            subj.getSubjectDay() == subject.getSubjectDay()
+                    )
+                    .anyMatch(subj -> subj.conflictCheck(subject))
+                    ;
+
+            int isSameCode = member.getMemberSubjects().stream()
+                    .map(MemberSubject::getSubject)
+                    .filter(subj ->
+                            subj.getCode().equals(subject.getCode())
+                    )
+                    .toList()
+                    .size()
+                    ;
+
+            if (conflict) {
+                log.error("시간 충돌");
+                throw new ErrorHandler(ErrorStatus.CONFLICT_COURSE_TIME);
+            }
+
+            if (isSameCode != 0) {
+                log.error("이미 신청한 과목");
+                throw new ErrorHandler(ErrorStatus.ALREADY_APPLY_SUBJECT);
+            }
+
+            int result = subjectRepository.tryIncreaseRegistered(subject.getId());
+
+            if (result == 0) {
+                log.error("제한인원 초과, 제한인원 : " + subject.getLimitedNum() + " , 신청인원 : " + subject.getRegisteredNum());
+                throw new ErrorHandler(ErrorStatus.CAPACITY_FULL);
+            }
+
+            // 신청학점 추가
+            member.addScore(subject.getScore());
+
+            // 저장
+            MemberSubject memberSubject = MemberSubject.builder()
+                    .member(member)
+                    .subject(subject)
+                    .build();
+
+            memberSubjectRepository.save(memberSubject);
+            member.getMemberSubjects().add(memberSubject);
+            subject.getMemberSubjects().add(memberSubject);
+
+        } catch (ErrorHandler e) {
+            idempotencyService.releaseIdempotency(memberId, code);
+            throw e;
         }
-
-        if (isSameCode != 0) {
-            log.error("이미 신청한 과목");
-            throw new ErrorHandler(ErrorStatus.ALREADY_APPLY_SUBJECT);
+        finally {
+            idempotencyService.releaseIdempotency(memberId, code);
         }
-
-        int result = subjectRepository.tryIncreaseRegistered(subject.getId());
-
-        if (result == 0) {
-            log.error("제한인원 초과, 제한인원 : " + subject.getLimitedNum() + " , 신청인원 : " + subject.getRegisteredNum());
-            throw new ErrorHandler(ErrorStatus.CAPACITY_FULL);
-        }
-
-        // 신청학점 추가
-        member.addScore(subject.getScore());
-
-        // 저장
-        MemberSubject memberSubject = MemberSubject.builder()
-                .member(member)
-                .subject(subject)
-                .build();
-
-        memberSubjectRepository.save(memberSubject);
-        member.getMemberSubjects().add(memberSubject);
-        subject.getMemberSubjects().add(memberSubject);
-
     }
 
 

--- a/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/practice/course_registration/global/apiPayload/code/status/ErrorStatus.java
@@ -34,6 +34,11 @@ public enum ErrorStatus implements BaseErrorCode {
     CAPACITY_FULL(HttpStatus.BAD_REQUEST, "SUBJECT4005", "제한 인원이 가득 찼습니다."),
     OVER_SOCRE_POSSIBLE(HttpStatus.BAD_REQUEST, "SUBJECT4006", "신청 가능한 학점을 초과했습니다."),
 
+
+    // apply (수강신청 관련)
+    TOO_MANY_REQUESTS(HttpStatus.BAD_REQUEST, "APPLY4001", "처리중입니다."),
+    DUPLICATE_REQUEST(HttpStatus.BAD_REQUEST, "APPLY4002", "동일한 요청이 이미 처리중입니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/practice/course_registration/global/redis/service/IdempotencyService.java
+++ b/src/main/java/com/practice/course_registration/global/redis/service/IdempotencyService.java
@@ -1,0 +1,45 @@
+package com.practice.course_registration.global.redis.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IdempotencyService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private static final String RATE_LIMIT_KEY_PREFIX = "rate:limit:"; // rate limit key
+    private static final String IDEMPOTENCY_KEY_PREFIX = "idem:"; // 멱등키 prefix
+
+    public boolean rateLimitAllow(String k, int limit, Duration ttl) {
+        String key = RATE_LIMIT_KEY_PREFIX + k;
+        Long cnt = stringRedisTemplate.opsForValue().increment(key);
+        System.out.println("cnt : " + cnt);
+        // 첫 요청인 경우 -> TTL 1로 세팅
+        if (cnt != null && cnt == 1L) {
+            stringRedisTemplate.expire(key, ttl);
+        }
+
+        return cnt != null && cnt <= limit;
+    }
+
+    public boolean acquireIdempotency(Long memberId, String subjectCode, Duration ttl) {
+        String key = makeIdemKey(memberId, subjectCode);
+
+        // key 없을 때 만들어서 1 넣기
+        Boolean isSuccess = stringRedisTemplate.opsForValue().setIfAbsent(key, "1", ttl);
+        return Boolean.TRUE.equals(isSuccess);
+    }
+
+    // 멱등키 제거
+    public void releaseIdempotency(Long memberId, String subjectCode) {
+        stringRedisTemplate.delete(makeIdemKey(memberId, subjectCode));
+    }
+
+    private String makeIdemKey(Long memberId, String subjectCode) {
+        return IDEMPOTENCY_KEY_PREFIX + memberId + ":" + subjectCode;
+    }
+
+}

--- a/src/main/java/com/practice/course_registration/global/redis/test/RedisHealthCheck.java
+++ b/src/main/java/com/practice/course_registration/global/redis/test/RedisHealthCheck.java
@@ -1,18 +1,42 @@
-package com.practice.course_registration.global.redis.test;
-
+package com.practice.course_registration.global.redis.test;// package com.practice.course_registration.global.redis.debug;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
+@Profile("!test") // 테스트 제외(선택)
 @RequiredArgsConstructor
 public class RedisHealthCheck implements CommandLineRunner {
+
     private final StringRedisTemplate redis;
+    private final RedisConnectionFactory cf;
 
     @Override
     public void run(String... args) {
-        redis.opsForValue().set("test:key", "HelloRedis");
-        System.out.println("✅ Redis connected: " + redis.opsForValue().get("test:key"));
+        String key = "debug:hello";
+        redis.opsForValue().set(key, "fromApp", Duration.ofMinutes(10));
+
+        String pong = redis.execute((RedisCallback<String>) conn -> conn.ping());
+        String val  = redis.opsForValue().get(key);
+
+        String host = "unknown";
+        int port = -1;
+        int db = -1;
+        if (cf instanceof LettuceConnectionFactory lcf) {
+            host = lcf.getHostName();
+            port = lcf.getPort();
+            db   = lcf.getDatabase();
+        }
+
+        log.info("🔎 REDIS DEBUG host={}, port={}, db={}, ping={}, key={}, val={}",
+                host, port, db, pong, key, val);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: prod
   h2:
     console:
       enabled: false
@@ -26,6 +28,7 @@ spring:
       host: redis
       port: 6379
       connect-timeout: 2000
+      database: 0
 
   #  mvc:
   #    throw-exception-if-no-handler-found: true


### PR DESCRIPTION
## ❤️ 기능 설명
- SSR 방식이다 보니 더블클릭을 서버에서 컨트롤 해야함 -> 멱등키를 이용해서 여러번 클릭 시 한번만 적용되도록 구현
- 봇을 이용해서 초당 너무 많이 요청을 보내는 등의 경우를 막기 위해 rate limit도 key로 뽑아서 초당 5번 이상의 요청이 불가능하게 제어 
    -> 입구에서 아예 트래픽이 과도하게 늘어나는 걸 방지


테스트 성공 결과 스크린샷 첨부

redis연결
<img width="2325" height="254" alt="image" src="https://github.com/user-attachments/assets/5dfe9e49-89e2-4bf9-a149-0331032ca196" />

rate limit key 개수 확인
<img width="485" height="320" alt="image" src="https://github.com/user-attachments/assets/efac060b-4810-4c0b-9e31-2e883ec9f83a" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #48 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [x] yml파일들에 profile 설정해두었슴니다 배포 서버에서는 prod프로필 쓴다고 설정 해두어야 할 거 가타요 아마도 cd에!!!
- [x] 이제 atomic하게 처리하도록 추가 구현을 할 예정임니다 ~!!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
