### PR TITLE
[Feat/#50] 메시지 발급 과정에서 생길 수 있는 오류 세분화 처리 

### DIFF
--- a/src/main/java/com/practice/course_registration/global/kafka/KafkaProducer.java
+++ b/src/main/java/com/practice/course_registration/global/kafka/KafkaProducer.java
@@ -61,12 +61,16 @@ public class KafkaProducer {
 
     // Message를 발급하는 과정에서 생긴 오류 핸들링
     private <T> void handleException(Throwable ex, RegistrationMessage message) {
-        if (ex.getCause() instanceof RetriableException){
-            log.warn("Retriable Exception이 발생하였습니다. 자동으로 다시 시도합니다. {}", ex.getMessage());
-        } else if (ex.getCause() instanceof SerializationException){
-            log.error("Serialization 요류입니다. 메시지를 확인하세요. {}", message, ex.getMessage());
+        // cause가 있으면 cause를, 없으면 ex 자체를 확인
+        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+
+        if (cause instanceof RetriableException){
+            log.warn("Retriable Exception이 발생하였습니다. 자동으로 다시 시도합니다. {}", cause.getMessage());
+        } else if (cause instanceof SerializationException){
+            log.error("Serialization 오류입니다. DLT로 전송합니다. {}", message);
+            sendToDeadLetterTopic(message, targetTopic);
         } else {
-            log.error("{} 메시지를 dead-letter queue로 전송합니다. 에러는 다음과 같습니다. {}", message, ex.getMessage());
+            log.error("{} 메시지를 dead-letter queue로 전송합니다. 에러는 다음과 같습니다. {}", message, cause.getMessage());
             sendToDeadLetterTopic(message, targetTopic);
         }
     }

--- a/src/main/java/com/practice/course_registration/global/kafka/KafkaProducer.java
+++ b/src/main/java/com/practice/course_registration/global/kafka/KafkaProducer.java
@@ -1,6 +1,8 @@
 package com.practice.course_registration.global.kafka;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.SerializationException;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
@@ -12,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public class KafkaProducer {
     private final KafkaTemplate<String, RegistrationMessage> kafkaTemplate;
+    private final String targetTopic = "registration-queue";
 
     public KafkaProducer(KafkaTemplate<String, RegistrationMessage> kafkaTemplate) {
         this.kafkaTemplate = kafkaTemplate;
@@ -28,22 +31,49 @@ public class KafkaProducer {
         );
 
         // 비동기로 카프카에 전송
-        CompletableFuture<SendResult<String, RegistrationMessage>> future =
-                kafkaTemplate.send("registration-queue", subjectCode, message);
+        try{
+            CompletableFuture<SendResult<String, RegistrationMessage>> future =
+                    kafkaTemplate.send(targetTopic, subjectCode, message);
 
-        future.whenComplete((result, ex) -> {
-            if (ex == null){
-                log.info("메시지 전송 성공 - requestId: {}, topic: {}, partition: {}, offset: {}",
-                        requestId,
-                        result.getRecordMetadata().topic(),
-                        result.getRecordMetadata().partition(),
-                        result.getRecordMetadata().offset());
-            }
-            else {
-                log.error("메시지 전송 실패 - requestId: {}, userId: {}, subjectCode: {}, error: {}",
-                        requestId, userId, subjectCode, ex.getMessage());
-            }
-        });
+            future.whenCompleteAsync((result, ex) -> {
+                if (ex == null){
+                    onSuccess(result, message, requestId);
+                }
+                else {
+                    // 비동기 실패
+                    handleException(ex, message);
+                }
+            });
+        } catch (Exception ex){
+            // 동기 실패
+            handleException(ex, message);
+        }
+    }
 
+    private <T> void onSuccess(final SendResult<String, RegistrationMessage> result, final T t, String requestId){
+        log.info("성공적인 메시지 =[{}] request-id= {} topic-partition={}-{} offset={}",
+                t,
+                requestId,
+                result.getRecordMetadata().topic(),
+                result.getRecordMetadata().partition(),
+                result.getRecordMetadata().offset());
+    }
+
+    // Message를 발급하는 과정에서 생긴 오류 핸들링
+    private <T> void handleException(Throwable ex, RegistrationMessage message) {
+        if (ex.getCause() instanceof RetriableException){
+            log.warn("Retriable Exception이 발생하였습니다. 자동으로 다시 시도합니다. {}", ex.getMessage());
+        } else if (ex.getCause() instanceof SerializationException){
+            log.error("Serialization 요류입니다. 메시지를 확인하세요. {}", message, ex.getMessage());
+        } else {
+            log.error("{} 메시지를 dead-letter queue로 전송합니다. 에러는 다음과 같습니다. {}", message, ex.getMessage());
+            sendToDeadLetterTopic(message, targetTopic);
+        }
+    }
+
+    private <T> void sendToDeadLetterTopic(T message, final String topic){
+        String deadLetterTopic = topic + ".DLT";
+        log.info("DLT로 메시지를 보냅니다 : {}", deadLetterTopic);
+        kafkaTemplate.send(deadLetterTopic, (RegistrationMessage) message);
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,31 @@
+spring:
+  application:
+    name: course-registration
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  kafka:
+    bootstrap-servers: localhost:29092,localhost:29093,localhost:29094
+
+server:
+  servlet:
+    session:
+      timeout: 30m

--- a/src/test/java/com/practice/course_registration/KafkaProducerTest.java
+++ b/src/test/java/com/practice/course_registration/KafkaProducerTest.java
@@ -1,0 +1,7 @@
+package com.practice.course_registration;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class KafkaProducerTest {
+}

--- a/src/test/java/com/practice/course_registration/KafkaProducerTest.java
+++ b/src/test/java/com/practice/course_registration/KafkaProducerTest.java
@@ -1,7 +1,65 @@
 package com.practice.course_registration;
 
-import org.springframework.boot.test.context.SpringBootTest;
+import com.practice.course_registration.global.kafka.KafkaProducer;
+import com.practice.course_registration.global.kafka.RegistrationMessage;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import java.util.concurrent.CompletableFuture;
 
-@SpringBootTest
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class KafkaProducerTest {
+    @Mock
+    private KafkaTemplate<String, RegistrationMessage> kafkaTemplate;
+    @InjectMocks
+    KafkaProducer kafkaProducer;
+
+
+    @Test
+    @DisplayName("예외 발생 시 DLT로 전송한다.")
+    void ShouldSendToDLT() {
+        // given
+        when(kafkaTemplate.send(anyString(), anyString(), any()))
+                .thenReturn(CompletableFuture.failedFuture(
+                        new RuntimeException("브로커 이용 불가")
+                ));
+
+        // when
+        kafkaProducer.create(1L, "TEST1");
+
+        // then
+        verify(kafkaTemplate, timeout(1000))
+                .send(eq("registration-queue.DLT"), any(RegistrationMessage.class));
+    }
+
+
+    @Test
+    @DisplayName("RetriableException은 DLT로 안보낸다")
+    void ShouldNotSendToDLT() {
+        // given
+        when(kafkaTemplate.send(anyString(), anyString(), any()))
+                .thenReturn(CompletableFuture.failedFuture(
+                        new TimeoutException("Temporary failure")
+                ));
+
+        // when
+        kafkaProducer.create(1L, "TEST1");
+
+        // then
+        verify(kafkaTemplate, times(1))
+                .send(eq("registration-queue"), anyString(), any());
+
+        verify(kafkaTemplate, never())
+                .send(eq("registration-queue.DLT"), any());
+
+    }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
- callBack 기능이 이미 구현되어 있어서, 기존의 코드에서 `whenComplete`를 `whenCompleteAsync` 메소드로 명시적으로 바꿨습니다.
- 아래의 깃허브를 참고하여, Produce 시에 에러 났으면, 해당 메시지를 DLT 토픽으로 보내게끔 수정하였습니다.

- 예외 처리 개선:
  - `RetriableException`: 자동 재시도 (DLT 전송 X)
  - `SerializationException`: DLT로 전송
  - 기타 예외: DLT로 전송

- `handleException` 메서드에서 `ex.getCause()`가 null인 경우를 처리하여, 감싸지지 않은 예외도 정확히 분류

- 참고 : https://github.com/PouyaPouryaie/springboot-kafka/blob/main/error-handling/src/main/java/ir/bigz/kafka/publisher/KafkaMessagePublisher.java

테스트 성공 결과 스크린샷 첨부
- 일반 예외 발생 시 DLT 전송 테스트
- RetriableException 발생 시 DLT 미전송 테스트

<img width="1423" height="337" alt="image" src="https://github.com/user-attachments/assets/b80fc154-4d81-4eb6-9030-59b39cbc1750" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #50 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] Consumer 측에서 `registration-queue.DLT` 토픽 구독되는지 확인해주세요
- [ ] DLT에 쌓인 메시지는 어떻게 할까요

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
