### PR TITLE
fix/#60: luaRepositoy 배포환경 생성자 오류 해결

### DIFF
--- a/src/main/java/com/practice/course_registration/global/redis/repository/LuaRepository.java
+++ b/src/main/java/com/practice/course_registration/global/redis/repository/LuaRepository.java
@@ -11,6 +11,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.FileCopyUtils;
 
 /*
 * @TODO
@@ -70,7 +71,10 @@ public class LuaRepository {
 
     private <T> DefaultRedisScript<T> script(String path, Class<T> type) {
         try {
-            var txt = Files.readString(new ClassPathResource(path).getFile().toPath(), StandardCharsets.UTF_8);
+            ClassPathResource resource = new ClassPathResource(path);
+            byte[] binaryData = FileCopyUtils.copyToByteArray(resource.getInputStream());
+            String txt = new String(binaryData, StandardCharsets.UTF_8);
+
             var s = new DefaultRedisScript<T>();
             s.setScriptText(txt);
             s.setResultType(type);


### PR DESCRIPTION
## ❤️ 기능 설명
- 배포 환경에서 luaRepository에서 classPath 불러올 때 File 읽어오는 걸로 하니까 오류가 발생하여 초기화를 못하는 문제가 있었습니다.
- getInputStream을 이용하여 오류를 해결하였습니다. 
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{} 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 저 부분 잘 모르겠어서 한 번 알아봐야할 것 같아용

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
