### PR TITLE
[Refact] SecurityConfig 비활성화 및 기능 분리

### DIFF
--- a/src/main/java/com/practice/course_registration/CourseRegistrationApplication.java
+++ b/src/main/java/com/practice/course_registration/CourseRegistrationApplication.java
@@ -1,15 +1,18 @@
 package com.practice.course_registration;
 
+import com.practice.course_registration.global.security.utils.HeaderUserIdProvider;
+import com.practice.course_registration.global.security.utils.SecurityUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 public class CourseRegistrationApplication {
-
 	public static void main(String[] args) {
-		SpringApplication.run(CourseRegistrationApplication.class, args);
+		ConfigurableApplicationContext context = SpringApplication.run(CourseRegistrationApplication.class, args);
+        HeaderUserIdProvider headerUserIdProvider = context.getBean(HeaderUserIdProvider.class);
+        SecurityUtils.setUserIdProvider(headerUserIdProvider);
 	}
-
 }

--- a/src/main/java/com/practice/course_registration/CourseRegistrationApplication.java
+++ b/src/main/java/com/practice/course_registration/CourseRegistrationApplication.java
@@ -12,7 +12,5 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class CourseRegistrationApplication {
 	public static void main(String[] args) {
 		ConfigurableApplicationContext context = SpringApplication.run(CourseRegistrationApplication.class, args);
-        HeaderUserIdProvider headerUserIdProvider = context.getBean(HeaderUserIdProvider.class);
-        SecurityUtils.setUserIdProvider(headerUserIdProvider);
 	}
 }

--- a/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectController.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectController.java
@@ -8,11 +8,14 @@ import com.practice.course_registration.domain.subject.service.SubjectService;
 import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
 import com.practice.course_registration.global.kafka.KafkaProducer;
 import com.practice.course_registration.global.redis.service.WaitQueueService;
+import com.practice.course_registration.global.redis.utils.RedisKeyUtils;
 import com.practice.course_registration.global.security.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -29,12 +32,12 @@ import java.util.Map;
 @RequiredArgsConstructor
 @RequestMapping("/courses")
 @Validated
+@Slf4j
 public class SubjectController {
 
     private final SubjectQueryService subjectQueryService;
     private final SubjectService subjectService;
     private final WaitQueueService waitQueueService;
-
 
     /*
     * 기본 수강신청 페이지
@@ -84,7 +87,6 @@ public class SubjectController {
             response.put("status", "WAITING");
             response.put("message", "대기열에 진입했습니다.");
             return ResponseEntity.ok(response);
-
         } catch (ErrorHandler e) {
             // 에러 시 JSON 응답
             response.put("status", "FAIL");

--- a/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectController.java
+++ b/src/main/java/com/practice/course_registration/domain/subject/controller/SubjectController.java
@@ -119,11 +119,7 @@ public class SubjectController {
             String tokenVal = waitQueueService.peekToken(memberId);
 
             if (tokenVal != null) {
-                // [성공 케이스] 토큰 있음 -> 수강신청 확정 로직 수행
-                subjectService.applyCourseWithToken(memberId, code);
-
-                response.put("status", "SUCCESS");
-                response.put("message", "수강신청이 완료되었습니다.");
+                response.put("status", "ALLOWED");
             } else {
                 // [대기 케이스] 토큰 없음 -> 현재 대기 순번 조회
                 WaitPositionDTO dto = subjectService.getWaitPosition(memberId, code);
@@ -139,5 +135,17 @@ public class SubjectController {
             response.put("message", e.getErrorReason().getMessage());
             return ResponseEntity.ok(response); // 200 OK로 보내되, 내용은 FAIL 처리
         }
+    }
+
+    @PostMapping("/apply/confirm")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> confirmApply(@RequestParam String code) {
+        Map<String, Object> response = new HashMap<>();
+        Long memberId = SecurityUtils.getUserId();
+        subjectService.applyCourseWithToken(memberId, code);
+
+        response.put("status", "SUCCESS");
+        response.put("message", "수강신청이 완료되었습니다.");
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/practice/course_registration/global/config/SecurityConfig.java
+++ b/src/main/java/com/practice/course_registration/global/config/SecurityConfig.java
@@ -33,10 +33,11 @@ public class SecurityConfig {
                         .expiredUrl("/session/expired")
                 );
         http
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/h2-console/**", "/join", "/session/expired", "/login").permitAll() // 일단 개발을 위해서 모든 접근 허용. 필요 시 수정
-                        .anyRequest().authenticated() // 로그인한 회원만 like 페이지에 접속 가능한 것 확인.
+                .authorizeHttpRequests((auth) -> auth.anyRequest().permitAll()
+//                        .requestMatchers("/h2-console/**", "/join", "/session/expired", "/login").permitAll() // 일단 개발을 위해서 모든 접근 허용. 필요 시 수정
+//                        .anyRequest().hasRole("ROLE_USER") // 로그인한 회원만 like 페이지에 접속 가능한 것 확인.
                 );
+
 
         http
                 .formLogin((form) -> form

--- a/src/main/java/com/practice/course_registration/global/redis/service/PublishIssueTokenScheduler.java
+++ b/src/main/java/com/practice/course_registration/global/redis/service/PublishIssueTokenScheduler.java
@@ -14,7 +14,7 @@ public class PublishIssueTokenScheduler {
     private final LuaRepository luaRepository;
 
     private static final int PERMITS_PER_TICKS = 50;   // tick당 최대 발급 수
-    private static final int TOKEN_TTL = 3; // token ttl
+    private static final int TOKEN_TTL = 5; // token ttl
 
     @Scheduled(fixedDelay = 100)
     public void issue() {

--- a/src/main/java/com/practice/course_registration/global/redis/service/WaitQueueService.java
+++ b/src/main/java/com/practice/course_registration/global/redis/service/WaitQueueService.java
@@ -48,9 +48,7 @@ public class WaitQueueService {
         String tokenKey = RedisKeyUtils.applyTokenKey(memberId);
         String redisSubjectId = redisTemplate.opsForValue().get(tokenKey);
         if (redisSubjectId == null) return false;
-        if (!redisSubjectId.equals(String.valueOf(subjectId))) return false;
         redisTemplate.delete(tokenKey); // 일회성
         return true;
     }
-
 }

--- a/src/main/java/com/practice/course_registration/global/security/utils/HeaderUserIdProvider.java
+++ b/src/main/java/com/practice/course_registration/global/security/utils/HeaderUserIdProvider.java
@@ -1,0 +1,17 @@
+package com.practice.course_registration.global.security.utils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class HeaderUserIdProvider implements UserIdProvider {
+    @Override
+    public Long getUserId() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String userId = request.getHeader("userId");
+        return Long.parseLong(userId);
+    }
+}

--- a/src/main/java/com/practice/course_registration/global/security/utils/HeaderUserIdProvider.java
+++ b/src/main/java/com/practice/course_registration/global/security/utils/HeaderUserIdProvider.java
@@ -1,17 +1,31 @@
 package com.practice.course_registration.global.security.utils;
 
+import com.practice.course_registration.global.apiPayload.code.status.ErrorStatus;
+import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Component
+@Primary
 public class HeaderUserIdProvider implements UserIdProvider {
     @Override
     public Long getUserId() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
         String userId = request.getHeader("userId");
-        return Long.parseLong(userId);
+        if (userId == null || userId.isEmpty()){
+            throw new ErrorHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        try{
+            return Long.parseLong(userId);
+        }
+        catch (NumberFormatException e){
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/practice/course_registration/global/security/utils/SecurityContextUserIdProvider.java
+++ b/src/main/java/com/practice/course_registration/global/security/utils/SecurityContextUserIdProvider.java
@@ -1,0 +1,29 @@
+package com.practice.course_registration.global.security.utils;
+
+import com.practice.course_registration.global.apiPayload.code.status.ErrorStatus;
+import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
+import com.practice.course_registration.global.security.domain.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityContextUserIdProvider implements UserIdProvider {
+    @Override
+    public Long getUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()){
+            throw new ErrorHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof CustomUserDetails)){
+            throw new ErrorHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) principal;
+
+        return customUserDetails.getID();
+    }
+}

--- a/src/main/java/com/practice/course_registration/global/security/utils/SecurityUtils.java
+++ b/src/main/java/com/practice/course_registration/global/security/utils/SecurityUtils.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SecurityUtils {
     private static UserIdProvider userIdProvider;
-    public SecurityUtils(@Qualifier("securityContextUserIdProvider") UserIdProvider userIdProvider) {
+    public SecurityUtils(UserIdProvider userIdProvider) {
         this.userIdProvider = userIdProvider;
     }
 

--- a/src/main/java/com/practice/course_registration/global/security/utils/SecurityUtils.java
+++ b/src/main/java/com/practice/course_registration/global/security/utils/SecurityUtils.java
@@ -3,24 +3,24 @@ package com.practice.course_registration.global.security.utils;
 import com.practice.course_registration.global.apiPayload.code.status.ErrorStatus;
 import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
 import com.practice.course_registration.global.security.domain.CustomUserDetails;
+import org.apache.catalina.User;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 
+@Component
 public class SecurityUtils {
+    private static UserIdProvider userIdProvider;
+    public SecurityUtils(@Qualifier("securityContextUserIdProvider") UserIdProvider userIdProvider) {
+        this.userIdProvider = userIdProvider;
+    }
+
     public static Long getUserId(){
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return userIdProvider.getUserId();
+    }
 
-        if (authentication == null || !authentication.isAuthenticated()){
-            throw new ErrorHandler(ErrorStatus._UNAUTHORIZED);
-        }
-
-        Object principal = authentication.getPrincipal();
-        if (!(principal instanceof CustomUserDetails)){
-            throw new ErrorHandler(ErrorStatus._UNAUTHORIZED);
-        }
-
-        CustomUserDetails customUserDetails = (CustomUserDetails) principal;
-
-        return customUserDetails.getID();
+    public static void setUserIdProvider(UserIdProvider userIdProvider){
+        SecurityUtils.userIdProvider = userIdProvider;
     }
 }

--- a/src/main/java/com/practice/course_registration/global/security/utils/UserIdProvider.java
+++ b/src/main/java/com/practice/course_registration/global/security/utils/UserIdProvider.java
@@ -1,0 +1,5 @@
+package com.practice.course_registration.global.security.utils;
+
+public interface UserIdProvider {
+    Long getUserId();
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,10 +8,10 @@ spring:
     name: course-registration
 
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    url: jdbc:mysql://localhost:3306/course
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:

--- a/src/test/java/com/practice/course_registration/SecurityUtilsTest.java
+++ b/src/test/java/com/practice/course_registration/SecurityUtilsTest.java
@@ -3,6 +3,7 @@ package com.practice.course_registration;
 import com.practice.course_registration.global.apiPayload.code.status.ErrorStatus;
 import com.practice.course_registration.global.apiPayload.exception.handler.ErrorHandler;
 import com.practice.course_registration.global.security.domain.CustomUserDetails;
+import com.practice.course_registration.global.security.utils.SecurityContextUserIdProvider;
 import com.practice.course_registration.global.security.utils.SecurityUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +26,8 @@ public class SecurityUtilsTest {
     @Mock
     private Authentication authentication;
 
+    private SecurityContextUserIdProvider securityContextUserIdProvider =  new SecurityContextUserIdProvider();
+
     @Mock
     private CustomUserDetails customUserDetails;
 
@@ -33,6 +36,7 @@ public class SecurityUtilsTest {
 
     @BeforeEach
     void setUp() {
+        new SecurityUtils(securityContextUserIdProvider);
         SecurityContextHolder.setContext(securityContext);
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
- JMeter로 바로 수강신청하려면은 SecurityContext에서 UserDetails를 가져오는 방식을 사용하면 안될 것 같아서,
- 기존 코드 살려놓고, memberId를 바로 return하는 코드를 하나 더 만들어서 교체하는 방식으로 코드를 약간 수정했습니다.
- 그리고 GET /apply/try에서 내차례인지 확인하고 DB에 저장하는 기능을 모두 담당해서,
- DB에 저장하는 기능은 POST /apply/confirm으로 뺐습니다
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #70 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] main에서 setter로 바꿔버렸는데, 더 좋은 방식이 있을까요잉
- [ ] GET POST를 분리를 해놨는데, 마지막으로 POST 할 때 진짜 이 토큰이 대기열을 거쳐온 것인지 검증하는 부분이 필요할까요?

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
